### PR TITLE
Add automated release workflow with changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: python
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds Release Please automation for managing releases:
- Auto-generates `CHANGELOG.md` from conventional commits
- Creates release PRs with version bumps when releasable changes are merged
- Publishes GitHub releases when release PRs are merged

## How it works
1. Push commits to `main` using [conventional commit](https://www.conventionalcommits.org/) format:
   - `feat: add new indicator` → minor version bump
   - `fix: correct calculation` → patch version bump
   - `feat!: breaking change` → major version bump
2. Release Please opens a PR titled "chore(main): release X.Y.Z"
3. Merge that PR to create the GitHub release

## Test plan
- [x] Workflow file created
- [ ] Verify workflow runs on push to main

🤖 Generated with [Claude Code](https://claude.ai/code)