### PR TITLE
ci: add PR title validation for conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,7 +28,7 @@ jobs:
             chore
             revert
           requireScope: false
-          subjectPattern: ^[A-Z].+$
+          subjectPattern: ^[a-z].+$
           subjectPatternError: |
-            The subject "{subject}" must start with a capital letter.
-            Example: "feat: Add new indicator"
+            The subject "{subject}" must start with a lowercase letter.
+            Example: "feat: add new indicator"


### PR DESCRIPTION
## Summary
Adds a GitHub Action that validates PR titles follow [conventional commit](https://www.conventionalcommits.org/) format.

Valid prefixes: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`

## Setup Required (after merging)

1. **Enable squash merging** in repo settings:
   - Settings → General → Pull Requests
   - Check "Allow squash merging"
   - Set "Default commit message" to "Pull request title"

2. **Make this check required** (optional but recommended):
   - Settings → Branches → Add rule for `main`
   - Enable "Require status checks to pass"
   - Add "Validate PR Title" as required

## Test plan
- [x] Workflow file created
- [ ] Test with a PR that has invalid title (should fail)
- [ ] Test with a PR that has valid title like `feat: Add feature` (should pass)

🤖 Generated with [Claude Code](https://claude.ai/code)