### PR TITLE
ci: use full semver versions for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6.8.0
         with:
           version: "latest"
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v4.4.0
         with:
           release-type: python
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Updates GitHub Actions to use full semver versions (e.g., `v6.0.2` instead of `v6`).

This allows Renovate to properly pin SHA digests with specific version comments like `# v6.0.2` instead of just `# v6`.

## Changes
| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v6 | v6.0.2 |
| astral-sh/setup-uv | v4 | v6.8.0 |
| amannn/action-semantic-pull-request | v5 | v5.5.3 |
| googleapis/release-please-action | v4 | v4.4.0 |

## Test plan
- [ ] CI passes with new versions
- [ ] Renovate creates PR to add SHA pins with full version comments

🤖 Generated with [Claude Code](https://claude.ai/code)