### PR TITLE
chore: add automerge rules for lockfile and GHA patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
   "platformAutomerge": true,
   "lockFileMaintenance": {
     "enabled": true,
+    "automerge": true,
     "schedule": [
       "before 6am on monday"
     ]
@@ -70,6 +71,17 @@
         "mypy"
       ],
       "groupName": "linting tools"
+    },
+    {
+      "description": "Automerge GitHub Actions patches",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true,
+      "minimumReleaseAge": "3 days"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- Enable automerge for lockfile maintenance PRs
- Add automerge rule for GitHub Actions patch updates with 3-day minimum release age

## Automerge Strategy

| Category | Update Type | Behavior |
|----------|-------------|----------|
| Dev dependencies | minor/patch | ✅ Automerge (already configured) |
| Lockfile maintenance | - | ✅ Automerge (new) |
| GitHub Actions | patch | ✅ Automerge (new) |
| GitHub Actions | minor | Manual review |
| All dependencies | major | Requires dashboard approval |

## Test plan
- [ ] Verify Renovate parses config correctly via dashboard
- [ ] Confirm automerge behavior on next dependency update

🤖 Generated with [Claude Code](https://claude.com/claude-code)