### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it through GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/pdemirdjian/volume-price-analysis/security)
+2. Click "Report a vulnerability"
+3. Provide details about the vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+## Scope
+
+The following are in scope for security reports:
+
+- The MCP server code (`src/volume_price_analysis/`)
+- Dependencies with known vulnerabilities
+
+The following are **out of scope**:
+
+- Third-party APIs (Yahoo Finance via yfinance)
+- Issues in upstream dependencies (report these to the respective projects)
+
+## Response
+
+I aim to respond to security reports within 7 days and will work to release a fix as soon as practical.
+
+## Supported Versions
+
+Only the latest release is supported with security updates.


### PR DESCRIPTION
## Summary
- Add SECURITY.md for responsible vulnerability disclosure
- Points users to GitHub's private vulnerability reporting feature
- Defines scope (MCP server code) and out-of-scope items (third-party APIs)

## Test plan
- [x] File renders correctly on GitHub
- [ ] Enable "Private vulnerability reporting" in repo Settings → Security (if not already enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)