### PR TITLE
ci: add minimal permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permission to CI workflow
- Follows principle of least privilege for GITHUB_TOKEN

## Why
By default, `GITHUB_TOKEN` has broader permissions than needed. This workflow only checks out code and runs local Python tooling (ruff, mypy, pytest), so it only needs read access to repository contents.

Explicitly declaring minimal permissions:
- Reduces attack surface if a dependency is compromised
- Makes the workflow's required permissions clear to reviewers
- Aligns with GitHub's security best practices

## Test plan
- [ ] CI workflow still passes (checkout, lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)