### PR TITLE
docs: fix indicator count in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ python -m volume_price_analysis.server
 ```
 src/volume_price_analysis/
 ├── server.py        # MCP server - tool definitions & handlers
-├── indicators.py    # Pure calculation functions (24+ indicators)
+├── indicators.py    # Pure calculation functions (23 indicators)
 └── data_fetcher.py  # Yahoo Finance data retrieval
 ```
 


### PR DESCRIPTION
## Summary
- Fixed the indicator count from "24+" to "23" to accurately reflect the number of functions in `indicators.py`

## Test plan
- [x] Verified count by grepping `^def ` in indicators.py (23 functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)