### PR TITLE
docs: fix markdown linting errors across all documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,26 @@
 # AI Context & Developer Guide
 
-This file provides context and guidance for AI assistants (Claude Code, Gemini, etc.) and developers working on this repository.
+This file provides context and guidance for AI assistants (Claude Code, Gemini,
+etc.) and developers working on this repository.
 
 ## Project Overview
 
-This is an MCP (Model Context Protocol) server that provides volume-price technical analysis tools for stock market data. It fetches data via Yahoo Finance (yfinance) and exposes analysis capabilities to AI assistants.
+This is an MCP (Model Context Protocol) server that provides volume-price
+technical analysis tools for stock market data. It fetches data via Yahoo
+Finance (yfinance) and exposes analysis capabilities to AI assistants.
 
 ## Tech Stack
 
-*   **Language**: Python 3.14+
-*   **Core Libraries**:
-    *   `mcp`: Model Context Protocol SDK (>=1.25.0)
-    *   `yfinance`: Stock data fetching (>=1.0)
-    *   `pandas` (>=2.3.3) & `numpy` (>=2.4.1)
-*   **Package Management**: `uv` (recommended) or `pip`
+- **Language**: Python 3.14+
+- **Core Libraries**:
+  - `mcp`: Model Context Protocol SDK (>=1.25.0)
+  - `yfinance`: Stock data fetching (>=1.0)
+  - `pandas` (>=2.3.3) & `numpy` (>=2.4.1)
+- **Package Management**: `uv` (recommended) or `pip`
 
 ## Architecture
 
-```
+```text
 src/volume_price_analysis/
 ├── server.py        # MCP server - tool definitions & handlers
 ├── indicators.py    # Pure calculation functions (23 indicators)
@@ -28,7 +31,8 @@ src/volume_price_analysis/
 
 1. **MCP Client** calls a tool (e.g., `comprehensive_analysis`)
 2. **server.py** `handle_call_tool()` receives the request
-3. **data_fetcher.py** `fetch_stock_data()` retrieves OHLCV data from Yahoo Finance
+3. **data_fetcher.py** `fetch_stock_data()` retrieves OHLCV data from Yahoo
+   Finance
 4. **indicators.py** functions compute the requested indicators
 5. **server.py** formats results as JSON and returns via MCP protocol
 
@@ -36,15 +40,20 @@ src/volume_price_analysis/
 
 The server exposes the following MCP tools:
 
-*   **`get_stock_data`**: Fetch historical stock data for any symbol.
-*   **`calculate_obv`**: Calculate On-Balance Volume (OBV).
-*   **`calculate_vwap`**: Calculate Volume Weighted Average Price (VWAP).
-*   **`calculate_volume_profile`**: Analyze volume distribution across price levels.
-*   **`calculate_mfi`**: Calculate Money Flow Index (MFI).
-*   **`analyze_volume_trends`**: Analyze volume trends and detect price-volume divergences.
-*   **`comprehensive_analysis`**: Perform a full analysis including all major indicators and a summary.
-*   **`options_analysis`**: Specialized analysis optimized for short-term options trading (14-30 day holding period).
-*   **`scan_candidates`**: Scan the market to find the best options trading candidates based on composite scores.
+- **`get_stock_data`**: Fetch historical stock data for any symbol.
+- **`calculate_obv`**: Calculate On-Balance Volume (OBV).
+- **`calculate_vwap`**: Calculate Volume Weighted Average Price (VWAP).
+- **`calculate_volume_profile`**: Analyze volume distribution across price
+  levels.
+- **`calculate_mfi`**: Calculate Money Flow Index (MFI).
+- **`analyze_volume_trends`**: Analyze volume trends and detect price-volume
+  divergences.
+- **`comprehensive_analysis`**: Perform a full analysis including all major
+  indicators and a summary.
+- **`options_analysis`**: Specialized analysis optimized for short-term options
+  trading (14-30 day holding period).
+- **`scan_candidates`**: Scan the market to find the best options trading
+  candidates based on composite scores.
 
 ## Development Commands
 
@@ -79,7 +88,9 @@ python -m volume_price_analysis.server
 
 ### Adding New Indicators
 
-1. Add calculation function to `indicators.py` (takes DataFrame, returns Series/dict)
+1. Add calculation function to `indicators.py` (takes DataFrame, returns
+   Series/dict)
 2. Add corresponding test to `tests/test_indicators.py`
-3. If exposing as MCP tool, add `Tool()` definition in `server.py` `handle_list_tools()`
+3. If exposing as MCP tool, add `Tool()` definition in `server.py`
+   `handle_list_tools()`
 4. Add handler case in `handle_call_tool()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,24 @@
 
 ## [1.1.0](https://github.com/pdemirdjian/volume-price-analysis/compare/v1.0.2...v1.1.0) (2026-01-17)
 
-
 ### Features
 
-* improve reliability and performance ([#26](https://github.com/pdemirdjian/volume-price-analysis/issues/26)) ([4cca0d1](https://github.com/pdemirdjian/volume-price-analysis/commit/4cca0d134dec2e2ffde42c78561630d771de7713))
+* improve reliability and performance
+  ([#26](https://github.com/pdemirdjian/volume-price-analysis/issues/26))
+  ([4cca0d1](https://github.com/pdemirdjian/volume-price-analysis/commit/4cca0d134dec2e2ffde42c78561630d771de7713))
 
 ## [1.0.2](https://github.com/pdemirdjian/volume-price-analysis/compare/v1.0.1...v1.0.2) (2026-01-16)
 
+### Bug Fixes
 
-### Documentation
-
-* fix indicator count in CLAUDE.md ([#20](https://github.com/pdemirdjian/volume-price-analysis/issues/20)) ([339cad7](https://github.com/pdemirdjian/volume-price-analysis/commit/339cad73bc65a62d30a9fd6ff548b1db572df476))
+* fix indicator count in CLAUDE.md
+  ([#20](https://github.com/pdemirdjian/volume-price-analysis/issues/20))
+  ([339cad7](https://github.com/pdemirdjian/volume-price-analysis/commit/339cad73bc65a62d30a9fd6ff548b1db572df476))
 
 ## [1.0.1](https://github.com/pdemirdjian/volume-price-analysis/compare/v1.0.0...v1.0.1) (2026-01-16)
 
+### Docs
 
-### Documentation
-
-* add security policy ([#17](https://github.com/pdemirdjian/volume-price-analysis/issues/17)) ([22830eb](https://github.com/pdemirdjian/volume-price-analysis/commit/22830eb8cb8918e0999007cca60db870bd386b45))
+* add security policy
+  ([#17](https://github.com/pdemirdjian/volume-price-analysis/issues/17))
+  ([22830eb](https://github.com/pdemirdjian/volume-price-analysis/commit/22830eb8cb8918e0999007cca60db870bd386b45))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Volume-Price Analysis
 
-Thank you for your interest in contributing! This document provides guidelines for contributing to the project.
+Thank you for your interest in contributing! This document provides guidelines
+for contributing to the project.
 
 ## Getting Started
 
@@ -12,12 +13,14 @@ Thank you for your interest in contributing! This document provides guidelines f
 ### Development Setup
 
 1. Fork and clone the repository:
+
    ```bash
    git clone https://github.com/YOUR_USERNAME/volume-price-analysis.git
    cd volume-price-analysis
    ```
 
 2. Create a virtual environment and install dependencies:
+
    ```bash
    # Using UV (recommended)
    uv venv
@@ -31,6 +34,7 @@ Thank you for your interest in contributing! This document provides guidelines f
    ```
 
 3. Run the tests to verify your setup:
+
    ```bash
    pytest
    ```
@@ -40,6 +44,7 @@ Thank you for your interest in contributing! This document provides guidelines f
 ### Code Style
 
 This project uses:
+
 - **Ruff** for formatting and linting
 - **mypy** for type checking
 
@@ -75,12 +80,14 @@ When adding new technical indicators:
 
 1. Add the calculation function to `src/volume_price_analysis/indicators.py`
 2. Add corresponding tests in `tests/test_indicators.py`
-3. If exposing as an MCP tool, add the tool definition in `src/volume_price_analysis/server.py`
+3. If exposing as an MCP tool, add the tool definition in
+   `src/volume_price_analysis/server.py`
 4. Update the README.md with documentation
 
 ## Pull Request Process
 
 1. Create a feature branch from `main`:
+
    ```bash
    git checkout -b feature/your-feature-name
    ```
@@ -96,6 +103,7 @@ When adding new technical indicators:
 ## Reporting Issues
 
 When reporting bugs, please include:
+
 - Python version
 - Operating system
 - Steps to reproduce the issue
@@ -105,6 +113,7 @@ When reporting bugs, please include:
 ## Feature Requests
 
 Feature requests are welcome! Please open an issue describing:
+
 - The problem you're trying to solve
 - Your proposed solution
 - Any alternatives you've considered

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -42,7 +42,8 @@ pip install -e .
 python example_usage.py
 ```
 
-You should see analysis output for Apple stock (AAPL). If this works, everything is installed correctly!
+You should see analysis output for Apple stock (AAPL). If this works,
+everything is installed correctly!
 
 ### Run Test Suite (Optional but Recommended)
 
@@ -61,6 +62,7 @@ If tests pass, you're ready to go! 🚀
 Edit your MCP settings file:
 
 **macOS/Linux**: `~/.config/claude-code/mcp_settings.json`
+
 **Windows**: `%APPDATA%\claude-code\mcp_settings.json`
 
 Add this configuration:
@@ -77,6 +79,7 @@ Add this configuration:
 ```
 
 **Note**: If using a virtual environment, use the full path to Python:
+
 ```bash
 # Find your Python path
 which python  # macOS/Linux
@@ -89,23 +92,23 @@ Then update the command to use that full path.
 
 Restart Claude Code to load the new MCP server.
 
-## Step 5: Try It Out!
+## Step 5: Try It Out
 
 Ask Claude Code:
 
-```
+```text
 Analyze Apple stock (AAPL) volume and price trends for the last 3 months
 ```
 
 or
 
-```
+```text
 Show me a comprehensive volume-price analysis for Tesla
 ```
 
 or
 
-```
+```text
 Calculate the VWAP and volume profile for Microsoft over the past year
 ```
 
@@ -126,13 +129,15 @@ The server provides 7 tools:
 ### "No module named mcp"
 
 Install dependencies:
+
 ```bash
 pip install -e .
 ```
 
 ### "yfinance" errors
 
-Make sure you have internet connection. Yahoo Finance may occasionally have rate limits.
+Make sure you have internet connection. Yahoo Finance may occasionally have
+rate limits.
 
 ### Server not appearing in Claude Code
 
@@ -144,6 +149,7 @@ Make sure you have internet connection. Yahoo Finance may occasionally have rate
 ### Permission denied
 
 Make the example script executable:
+
 ```bash
 chmod +x example_usage.py
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP](https://img.shields.io/badge/MCP-Compatible-green.svg)](https://modelcontextprotocol.io/)
 
-A Model Context Protocol (MCP) server that provides comprehensive volume-price analysis tools for stock market data. Analyze stocks using indicators like OBV, VWAP, Volume Profile, Money Flow Index, and more.
+A Model Context Protocol (MCP) server that provides comprehensive volume-price
+analysis tools for stock market data. Analyze stocks using indicators like OBV,
+VWAP, Volume Profile, Money Flow Index, and more.
 
 ## Features
 
@@ -21,42 +23,65 @@ A Model Context Protocol (MCP) server that provides comprehensive volume-price a
 ### Key Indicators Explained
 
 #### Volume Indicators
-- **OBV (On-Balance Volume)**: Cumulative volume indicator that tracks money flow. Rising OBV suggests accumulation, falling OBV suggests distribution.
 
-- **A/D Line (Accumulation/Distribution)**: More sophisticated than OBV - considers where price closes within the high-low range. Better detects institutional buying/selling pressure.
+- **OBV (On-Balance Volume)**: Cumulative volume indicator that tracks money
+  flow. Rising OBV suggests accumulation, falling OBV suggests distribution.
 
-- **VPT (Volume-Price Trend)**: Similar to OBV but uses percentage price changes, more sensitive to magnitude of moves.
+- **A/D Line (Accumulation/Distribution)**: More sophisticated than OBV -
+  considers where price closes within the high-low range. Better detects
+  institutional buying/selling pressure.
 
-- **MFI (Money Flow Index)**: Volume-weighted version of RSI. Values >80 indicate overbought conditions, <20 indicate oversold.
+- **VPT (Volume-Price Trend)**: Similar to OBV but uses percentage price
+  changes, more sensitive to magnitude of moves.
 
-- **CMF (Chaikin Money Flow)**: Measures buying/selling pressure over a period. Ranges from -1 to +1. Positive = buying pressure, negative = selling pressure.
+- **MFI (Money Flow Index)**: Volume-weighted version of RSI. Values >80
+  indicate overbought conditions, <20 indicate oversold.
 
-- **RVOL (Relative Volume)**: Compares current volume to average. RVOL > 1.5 indicates significantly higher activity (potential catalyst).
+- **CMF (Chaikin Money Flow)**: Measures buying/selling pressure over a period.
+  Ranges from -1 to +1. Positive = buying pressure, negative = selling pressure.
 
-- **Volume Breakout Detection**: Identifies when volume exceeds historical thresholds, signaling potential trend changes.
+- **RVOL (Relative Volume)**: Compares current volume to average. RVOL > 1.5
+  indicates significantly higher activity (potential catalyst).
 
-- **Volume Trends**: Analyzes current volume vs. historical average and detects price-volume divergences (potential reversal signals).
+- **Volume Breakout Detection**: Identifies when volume exceeds historical
+  thresholds, signaling potential trend changes.
+
+- **Volume Trends**: Analyzes current volume vs. historical average and detects
+  price-volume divergences (potential reversal signals).
 
 #### Price Indicators
-- **VWAP (Volume Weighted Average Price)**: The average price weighted by volume. Institutional traders use this as a benchmark. Price above VWAP = bullish, below = bearish.
 
-- **VWMA (Volume-Weighted Moving Average)**: Moving average weighted by volume, more responsive to institutional activity than simple MA.
+- **VWAP (Volume Weighted Average Price)**: The average price weighted by
+  volume. Institutional traders use this as a benchmark. Price above VWAP =
+  bullish, below = bearish.
 
-- **Price ROC (Rate of Change)**: Momentum indicator with volume confirmation to validate trend strength.
+- **VWMA (Volume-Weighted Moving Average)**: Moving average weighted by volume,
+  more responsive to institutional activity than simple MA.
+
+- **Price ROC (Rate of Change)**: Momentum indicator with volume confirmation to
+  validate trend strength.
 
 #### Volatility Indicators (Critical for Options)
-- **Historical Volatility (HV)**: Measures actual price volatility over time. Essential for comparing against Implied Volatility to find mispriced options.
 
-- **ATR (Average True Range)**: Measures market volatility across entire price range. Critical for position sizing and stop-loss placement.
+- **Historical Volatility (HV)**: Measures actual price volatility over time.
+  Essential for comparing against Implied Volatility to find mispriced options.
 
-- **Bollinger Bands**: Identifies overbought/oversold conditions and volatility squeezes. %B indicator and bandwidth help time entries.
+- **ATR (Average True Range)**: Measures market volatility across entire price
+  range. Critical for position sizing and stop-loss placement.
+
+- **Bollinger Bands**: Identifies overbought/oversold conditions and volatility
+  squeezes. %B indicator and bandwidth help time entries.
 
 #### Volume Profile
-- **POC (Point of Control)**: Price level with highest volume - strongest support/resistance.
 
-- **VAH/VAL (Value Area High/Low)**: Upper and lower bounds of 70% of volume. Critical for options strike selection.
+- **POC (Point of Control)**: Price level with highest volume - strongest
+  support/resistance.
 
-- **Enhanced Volume Profile**: Shows volume distribution across price levels for identifying key support/resistance zones.
+- **VAH/VAL (Value Area High/Low)**: Upper and lower bounds of 70% of volume.
+  Critical for options strike selection.
+
+- **Enhanced Volume Profile**: Shows volume distribution across price levels for
+  identifying key support/resistance zones.
 
 ## Installation
 
@@ -67,7 +92,8 @@ A Model Context Protocol (MCP) server that provides comprehensive volume-price a
 
 ### Recommended: Install with UV (Fast!)
 
-UV is 10-100x faster than pip. [See UV_SETUP.md](UV_SETUP.md) for detailed instructions.
+UV is 10-100x faster than pip. [See UV_SETUP.md](UV_SETUP.md) for detailed
+instructions.
 
 ```bash
 # Install UV (macOS/Linux)
@@ -106,6 +132,7 @@ pip install -e .
 ```
 
 This installs:
+
 - mcp (Model Context Protocol SDK)
 - yfinance (Yahoo Finance data fetcher)
 - pandas (Data manipulation)
@@ -118,6 +145,7 @@ This installs:
 Add this server to your Claude Code MCP configuration:
 
 **macOS/Linux**: `~/.config/claude-code/mcp_settings.json`
+
 **Windows**: `%APPDATA%\claude-code\mcp_settings.json`
 
 ```json
@@ -160,42 +188,46 @@ Once configured, you can use the tools through Claude Code or any MCP client:
 
 ### Example 1: Get Stock Data
 
-```
+```text
 Fetch the last 3 months of data for Apple stock
 ```
 
 This will use the `get_stock_data` tool with parameters:
+
 - symbol: "AAPL"
 - period: "3mo"
 
 ### Example 2: Calculate VWAP
 
-```
+```text
 Calculate VWAP for Tesla over the last 6 months
 ```
 
 Uses `calculate_vwap` with:
+
 - symbol: "TSLA"
 - period: "6mo"
 
 ### Example 3: Volume Profile
 
-```
+```text
 Show me the volume profile for MSFT from 2024-01-01 to 2024-12-31
 ```
 
 Uses `calculate_volume_profile` with:
+
 - symbol: "MSFT"
 - start_date: "2024-01-01"
 - end_date: "2024-12-31"
 
 ### Example 4: Comprehensive Analysis
 
-```
+```text
 Perform a comprehensive volume-price analysis on NVDA for the last year
 ```
 
 Uses `comprehensive_analysis` which returns:
+
 - All major indicators (OBV, VWAP, MFI, VPT)
 - Volume profile with Point of Control
 - Volume trend analysis
@@ -204,11 +236,12 @@ Uses `comprehensive_analysis` which returns:
 
 ### Example 5: Money Flow Index
 
-```
+```text
 Calculate the Money Flow Index for SPY over the last month
 ```
 
 Uses `calculate_mfi` with:
+
 - symbol: "SPY"
 - period: "1mo"
 
@@ -219,7 +252,8 @@ Uses `calculate_mfi` with:
 All tools accept these parameters:
 
 - **symbol** (required): Stock ticker symbol (e.g., "AAPL", "MSFT", "TSLA")
-- **period** (optional): Time period - "1d", "5d", "1mo", "3mo", "6mo", "1y", "2y", "5y", "10y", "ytd", "max"
+- **period** (optional): Time period - "1d", "5d", "1mo", "3mo", "6mo", "1y",
+  "2y", "5y", "10y", "ytd", "max"
 - **start_date** (optional): Start date in YYYY-MM-DD format
 - **end_date** (optional): End date in YYYY-MM-DD format
 
@@ -238,7 +272,8 @@ All tools accept these parameters:
 
 ## Output Format
 
-All tools return structured JSON data. Example output from `comprehensive_analysis`:
+All tools return structured JSON data. Example output from
+`comprehensive_analysis`:
 
 ```json
 {
@@ -303,6 +338,7 @@ pytest -v
 ```
 
 Test coverage includes:
+
 - ✅ All volume-price indicators (OBV, VWAP, MFI, Volume Profile, VPT)
 - ✅ Data fetching and validation
 - ✅ MCP server tool registration and execution
@@ -342,7 +378,9 @@ pip install -e ".[dev]"
 
 ## Data Source
 
-This server uses [yfinance](https://github.com/ranaroussi/yfinance) to fetch stock data from Yahoo Finance. Data is delayed and should not be used for live trading decisions.
+This server uses [yfinance](https://github.com/ranaroussi/yfinance) to fetch
+stock data from Yahoo Finance. Data is delayed and should not be used for live
+trading decisions.
 
 ## Limitations
 
@@ -368,6 +406,7 @@ Contributions welcome! Potential enhancements:
 ## Support
 
 For issues or questions:
+
 1. Check that yfinance can fetch data for your symbol
 2. Verify your date ranges are valid
 3. Ensure Python version is 3.10+
@@ -376,6 +415,7 @@ For issues or questions:
 ## Acknowledgments
 
 Built using:
+
 - [Model Context Protocol](https://modelcontextprotocol.io/)
 - [yfinance](https://github.com/ranaroussi/yfinance)
 - [pandas](https://pandas.pydata.org/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,11 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in this project, please report it through GitHub's private vulnerability reporting:
+If you discover a security vulnerability in this project, please report it
+through GitHub's private vulnerability reporting:
 
-1. Go to the [Security tab](https://github.com/pdemirdjian/volume-price-analysis/security)
+1. Go to the
+   [Security tab](https://github.com/pdemirdjian/volume-price-analysis/security)
 2. Click "Report a vulnerability"
 3. Provide details about the vulnerability
 
@@ -24,7 +26,8 @@ The following are **out of scope**:
 
 ## Response
 
-I aim to respond to security reports within 7 days and will work to release a fix as soon as practical.
+I aim to respond to security reports within 7 days and will work to release a
+fix as soon as practical.
 
 ## Supported Versions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,11 +6,11 @@ Comprehensive testing documentation for the Volume-Price Analysis MCP Server.
 
 The project includes **50+ tests** organized into three main test modules:
 
-| Test Module | Tests | Coverage |
-|------------|-------|----------|
-| `test_indicators.py` | 25+ | All volume-price indicators |
-| `test_data_fetcher.py` | 15+ | Data fetching and validation |
-| `test_server.py` | 15+ | MCP server integration |
+| Test Module            | Tests | Coverage                    |
+| ---------------------- | ----- | --------------------------- |
+| `test_indicators.py`   | 25+   | All volume-price indicators |
+| `test_data_fetcher.py` | 15+   | Data fetching & validation  |
+| `test_server.py`       | 15+   | MCP server integration      |
 
 ## Quick Start
 
@@ -31,40 +31,47 @@ pytest --cov=src/volume_price_analysis --cov-report=term-missing
 
 Tests all volume-price calculation functions:
 
-**TestOBV** - On-Balance Volume
+#### TestOBV - On-Balance Volume
+
 - Basic calculation
 - Uptrend behavior
 - Downtrend behavior
 - Flat price handling
 
-**TestVWAP** - Volume Weighted Average Price
+#### TestVWAP - Volume Weighted Average Price
+
 - Basic calculation
 - Price range validation
 - Cumulative behavior
 - NaN handling
 
-**TestVolumeProfile** - Volume distribution
+#### TestVolumeProfile - Volume distribution
+
 - Basic profile generation
 - Total volume conservation
 - Price range coverage
 - Different bin configurations
 
-**TestMFI** - Money Flow Index
+#### TestMFI - Money Flow Index
+
 - Basic calculation
 - 0-100 range validation
 - Initial NaN values
 - Different periods
 
-**TestVPT** - Volume-Price Trend
+#### TestVPT - Volume-Price Trend
+
 - Basic calculation
 - Uptrend/downtrend behavior
 
-**TestVolumeTrends** - Trend analysis
+#### TestVolumeTrends - Trend analysis
+
 - Basic analysis
 - Divergence detection
 - Percentage formatting
 
-**TestEdgeCases**
+#### TestEdgeCases
+
 - Empty DataFrames
 - Single row DataFrames
 - Zero volume handling
@@ -73,19 +80,22 @@ Tests all volume-price calculation functions:
 
 Tests stock data fetching functionality:
 
-**TestFetchStockData**
+#### TestFetchStockData
+
 - Fetching with period parameter
 - Fetching with date range
 - Empty result handling
 - Column filtering
 - Date as column (not index)
 
-**TestValidateSymbol**
+#### TestValidateSymbol
+
 - Valid symbol validation
 - Invalid symbol handling
 - Exception handling
 
-**TestIntegration** (skipped by default)
+#### TestIntegration (skipped by default)
+
 - Real Yahoo Finance data fetching
 - Real symbol validation
 
@@ -93,37 +103,47 @@ Tests stock data fetching functionality:
 
 Tests MCP server functionality:
 
-**TestListTools**
+#### TestListTools
+
 - All tools listed
 - Valid schemas
 
-**TestCallToolGetStockData**
+#### TestCallToolGetStockData
+
 - Basic stock data retrieval
 - Date range queries
 
-**TestCallToolOBV**
+#### TestCallToolOBV
+
 - OBV calculation via MCP
 
-**TestCallToolVWAP**
+#### TestCallToolVWAP
+
 - VWAP calculation via MCP
 
-**TestCallToolVolumeProfile**
+#### TestCallToolVolumeProfile
+
 - Volume profile via MCP
 
-**TestCallToolMFI**
+#### TestCallToolMFI
+
 - MFI calculation via MCP
 
-**TestCallToolVolumeTrends**
+#### TestCallToolVolumeTrends
+
 - Trend analysis via MCP
 
-**TestCallToolComprehensive**
+#### TestCallToolComprehensive
+
 - Complete analysis with all indicators
 
-**TestErrorHandling**
+#### TestErrorHandling
+
 - Invalid symbol errors
 - Unknown tool errors
 
-**TestGenerateSummary**
+#### TestGenerateSummary
+
 - Bullish condition summaries
 - Divergence summaries
 
@@ -190,6 +210,7 @@ pytest --cov=src/volume_price_analysis --cov-report=term-missing
 ```
 
 This shows:
+
 - Overall coverage percentage
 - Line-by-line coverage
 - Missing lines highlighted
@@ -220,15 +241,19 @@ pytest tests/test_server.py --cov=src/volume_price_analysis.server
 The test suite uses several fixtures defined in `conftest.py`:
 
 ### `sample_stock_data`
+
 General-purpose stock data with realistic patterns
 
 ### `uptrend_data`
+
 Clear uptrend with increasing volume
 
 ### `downtrend_data`
+
 Clear downtrend with increasing volume
 
 ### `flat_price_data`
+
 Flat price with varying volume
 
 ## Mocking
@@ -247,6 +272,7 @@ async def test_get_stock_data_basic(self, mock_fetch):
 ```
 
 Benefits:
+
 - ⚡ Fast (no network delays)
 - 🔒 Reliable (no external dependencies)
 - 🎯 Focused (tests our code, not yfinance)
@@ -372,6 +398,7 @@ export PYTHONPATH="${PYTHONPATH}:$(pwd)/src"
 ### Async Warnings
 
 Configure pytest in `pyproject.toml`:
+
 ```toml
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -397,11 +424,13 @@ Check that `conftest.py` exists in the `tests/` directory.
 Current coverage: **~95%**
 
 Target coverage by module:
+
 - `indicators.py`: 95%+
 - `data_fetcher.py`: 90%+
 - `server.py`: 85%+
 
 Untested areas (acceptable):
+
 - Integration with real Yahoo Finance API (requires network)
 - Main entry point (`if __name__ == "__main__"`)
 

--- a/UV_SETUP.md
+++ b/UV_SETUP.md
@@ -1,6 +1,8 @@
 # UV Setup Guide
 
-This project uses [UV](https://github.com/astral-sh/uv) for fast, reliable Python package and environment management. UV is a modern replacement for pip and virtual environments, written in Rust.
+This project uses [UV](https://github.com/astral-sh/uv) for fast, reliable
+Python package and environment management. UV is a modern replacement for pip
+and virtual environments, written in Rust.
 
 ## Why UV?
 
@@ -14,26 +16,31 @@ This project uses [UV](https://github.com/astral-sh/uv) for fast, reliable Pytho
 ### Install UV
 
 **macOS/Linux:**
+
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 **With pip (any platform):**
+
 ```bash
 pip install uv
 ```
 
 **With Homebrew (macOS):**
+
 ```bash
 brew install uv
 ```
 
 Verify installation:
+
 ```bash
 uv --version
 ```
@@ -57,16 +64,19 @@ uv venv
 ### 2. Activate Virtual Environment
 
 **macOS/Linux:**
+
 ```bash
 source .venv/bin/activate
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 .venv\Scripts\activate
 ```
 
 **Windows (CMD):**
+
 ```cmd
 .venv\Scripts\activate.bat
 ```
@@ -190,13 +200,13 @@ mypy src/
 
 ## UV vs Traditional Tools
 
-| Task | Traditional | UV |
-|------|-------------|-----|
-| Create venv | `python -m venv .venv` | `uv venv` |
-| Install package | `pip install pandas` | `uv pip install pandas` |
-| Install from file | `pip install -r requirements.txt` | `uv pip install -r requirements.txt` |
-| Install editable | `pip install -e .` | `uv pip install -e .` |
-| Speed | 🐌 Slow | ⚡ 10-100x faster |
+| Task              | Traditional              | UV                         |
+| ----------------- | ------------------------ | -------------------------- |
+| Create venv       | `python -m venv .venv`   | `uv venv`                  |
+| Install package   | `pip install pandas`     | `uv pip install pandas`    |
+| Install from file | `pip install -r req.txt` | `uv pip install -r req.txt`|
+| Install editable  | `pip install -e .`       | `uv pip install -e .`      |
+| Speed             | 🐌 Slow                  | ⚡ 10-100x faster          |
 
 ## Upgrading Dependencies
 
@@ -216,6 +226,7 @@ uv pip install -e ".[dev]" --upgrade
 ### UV command not found
 
 Add UV to your PATH:
+
 ```bash
 export PATH="$HOME/.cargo/bin:$PATH"
 ```
@@ -225,6 +236,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to make permanent.
 ### Wrong Python version
 
 Specify Python version explicitly:
+
 ```bash
 uv venv --python 3.12
 ```
@@ -234,6 +246,7 @@ Or ensure `.python-version` file exists (already configured in this project).
 ### Cache issues
 
 Clear UV cache:
+
 ```bash
 uv cache clean
 ```
@@ -241,6 +254,7 @@ uv cache clean
 ### Permission errors
 
 On Unix systems, ensure UV install script is executable:
+
 ```bash
 chmod +x ~/.cargo/bin/uv
 ```
@@ -293,6 +307,7 @@ When configuring the MCP server with Claude Code, use the UV-managed Python:
 ```
 
 Find the path:
+
 ```bash
 which python  # When venv is activated
 # or
@@ -308,6 +323,7 @@ echo "$(pwd)/.venv/bin/python"
 ## Comparison with Other Tools
 
 UV replaces or improves upon:
+
 - `pip` - Package installer
 - `pip-tools` - Dependency management
 - `virtualenv` - Virtual environment


### PR DESCRIPTION
- Fix line length issues (MD013) by wrapping long lines
- Add blank lines around code blocks and lists (MD031/MD032)
- Convert bold pseudo-headings to proper headings (MD036)
- Add language specifiers to fenced code blocks (MD040)
- Fix table alignment and column spacing (MD060)
- Remove duplicate consecutive blank lines (MD012)