### PR TITLE
chore(renovate): use fix commit type for Docker version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,17 @@
       "semanticCommitType": "fix"
     },
     {
+      "description": "Use fix commit type for Docker base image version updates",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "semanticCommitType": "fix"
+    },
+    {
       "description": "Automerge GitHub Actions patches and minor updates",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
## Summary

- Adds a `packageRule` so Renovate uses `fix:` commits for Docker base image minor/patch version bumps
- Digest-only updates (same tag, new hash) remain `chore:` and won't trigger releases
- Version tag changes (e.g. `3.13-slim` → `3.14-slim`) will now trigger a patch release via release-please

## Test plan

- [ ] Verify next Renovate Docker version-bump PR uses `fix(deps):` in its commit/title
- [ ] Verify digest-only PRs (like #194) still use `chore(deps):`

🤖 Generated with [Claude Code](https://claude.com/claude-code)