### PR TITLE
fix(renovate): use fix commit type for container-affecting updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,8 @@
     "automerge": true,
     "schedule": [
       "before 6am on monday"
-    ]
+    ],
+    "semanticCommitType": "fix"
   },
   "packageRules": [
     {
@@ -74,13 +75,14 @@
       "semanticCommitType": "fix"
     },
     {
-      "description": "Use fix commit type for Docker base image version updates",
+      "description": "Use fix commit type for Docker base image updates",
       "matchManagers": [
         "dockerfile"
       ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "digest"
       ],
       "semanticCommitType": "fix"
     },


### PR DESCRIPTION
## Summary

- Lock file maintenance now uses `fix:` — refreshing locks can pull in newer transitive dep versions that ship in the container
- Docker digest updates now use `fix:` — a new base image digest means a different container artifact

Both changes ensure release-please cuts a patch release when the container image changes, even if no application code changed.

## Test plan

- [ ] Next lock file maintenance PR uses `fix(deps):` in its title
- [ ] Next Docker digest PR (like #194) uses `fix(deps):` in its title

🤖 Generated with [Claude Code](https://claude.com/claude-code)