### PR TITLE
fix(renovate): revert lock file maintenance to chore commit type

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,8 +27,7 @@
     "automerge": true,
     "schedule": [
       "before 6am on monday"
-    ],
-    "semanticCommitType": "fix"
+    ]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Reverts the `semanticCommitType: fix` added to `lockFileMaintenance` in #198.

Using `fix:` caused a release-please loop:
1. Lock file maintenance merges → release-please bumps `pyproject.toml`
2. `uv.lock` becomes stale (root package version changed)
3. Renovate detects stale lock file → creates new lock file maintenance PR
4. Repeat indefinitely

Lock file maintenance stays `chore:` — transitive dep updates are already covered when Renovate explicitly bumps those packages with their own `fix:` PRs.

Docker digest updates keep their `fix:` type since those represent a concrete base image change in the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)