### PR TITLE
chore(renovate): automerge deps, batch majors, skip digest-only updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: build ──
-FROM python:3.14.3-slim-bookworm@sha256:f21c0d5a44c56805654c15abccc1b2fd576c8d93aca0a3f74b4aba2dc92510e2 AS builder
+FROM python:3.14.3-slim@sha256:5e59aae31ff0e87511226be8e2b94d78c58f05216efda3b07dbbed938ec8583b AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY src/ src/
 RUN uv sync --no-dev --frozen --no-editable
 
 # ── Stage 2: runtime ──
-FROM python:3.14.3-slim-bookworm@sha256:f21c0d5a44c56805654c15abccc1b2fd576c8d93aca0a3f74b4aba2dc92510e2
+FROM python:3.14.3-slim@sha256:5e59aae31ff0e87511226be8e2b94d78c58f05216efda3b07dbbed938ec8583b
 
 WORKDIR /app
 COPY --from=builder /app/.venv .venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: build ──
-FROM python:3.14.4-slim-trixie@sha256:5c9b9aeee369d854acd666375ebb2a9a45a8ac9d264973bed69dbb28cf48f648 AS builder
+FROM python:3.14.3-slim-bookworm@sha256:f21c0d5a44c56805654c15abccc1b2fd576c8d93aca0a3f74b4aba2dc92510e2 AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY src/ src/
 RUN uv sync --no-dev --frozen --no-editable
 
 # ── Stage 2: runtime ──
-FROM python:3.14.4-slim-trixie@sha256:5c9b9aeee369d854acd666375ebb2a9a45a8ac9d264973bed69dbb28cf48f648
+FROM python:3.14.3-slim-bookworm@sha256:f21c0d5a44c56805654c15abccc1b2fd576c8d93aca0a3f74b4aba2dc92510e2
 
 WORKDIR /app
 COPY --from=builder /app/.venv .venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: build ──
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa AS builder
+FROM python:3.14.4-slim-trixie@sha256:5c9b9aeee369d854acd666375ebb2a9a45a8ac9d264973bed69dbb28cf48f648 AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY src/ src/
 RUN uv sync --no-dev --frozen --no-editable
 
 # ── Stage 2: runtime ──
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.14.4-slim-trixie@sha256:5c9b9aeee369d854acd666375ebb2a9a45a8ac9d264973bed69dbb28cf48f648
 
 WORKDIR /app
 COPY --from=builder /app/.venv .venv

--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,17 @@
       "semanticCommitType": "fix"
     },
     {
+      "description": "Skip digest-only Dockerfile PRs; rely on apt-get upgrade at build time and Trivy scan for OS CVEs. Version bumps (major/minor/patch) still flow through.",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "pinDigest"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Automerge GitHub Actions patches and minor updates",
       "matchManagers": [
         "github-actions"

--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,6 @@
     "config:best-practices",
     ":semanticCommits"
   ],
-  "schedule": [
-    "before 6am on monday"
-  ],
   "timezone": "America/Los_Angeles",
   "labels": [
     "dependencies"
@@ -72,6 +69,27 @@
         "project.dependencies"
       ],
       "semanticCommitType": "fix"
+    },
+    {
+      "description": "Automerge non-major production dependencies with 3-day soak",
+      "matchDepTypes": [
+        "project.dependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Batch major-version bumps into the Monday review window",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "schedule": [
+        "before 6am on monday"
+      ]
     },
     {
       "description": "Use fix commit type for Docker base image updates",

--- a/renovate.json
+++ b/renovate.json
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "description": "Use fix commit type for Docker base image updates",
+      "description": "Automerge non-major Docker base image updates with 3-day soak; use fix commit type to trigger releases",
       "matchManagers": [
         "dockerfile"
       ],
@@ -101,7 +101,9 @@
         "patch",
         "digest"
       ],
-      "semanticCommitType": "fix"
+      "semanticCommitType": "fix",
+      "automerge": true,
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Skip digest-only Dockerfile PRs; rely on apt-get upgrade at build time and Trivy scan for OS CVEs. Version bumps (major/minor/patch) still flow through.",


### PR DESCRIPTION
## Summary
Restructured the Renovate configuration to implement a more sophisticated dependency update strategy with selective automerging and scheduled batching, while also updating the Python base image to 3.14.3.

## Key Changes

**Renovate Configuration:**
- Removed global `schedule` constraint (was limiting all updates to before 6am Monday)
- Added automerge for non-major production dependencies with 3-day minimum release age soak period
- Added scheduled batching for major version updates to Monday mornings for focused review
- Enhanced Docker base image update handling:
  - Automerge non-major updates (minor/patch/digest) with 3-day soak period
  - Disabled digest-only updates to rely on `apt-get upgrade` at build time and Trivy scanning for OS CVEs
  - Kept version bumps (major/minor/patch) flowing through the normal process
- Improved semantic commit messaging for Docker updates to clarify the automerge + fix commit type strategy

**Dockerfile:**
- Updated Python base image from `3.14-slim` to `3.14.3-slim` in both build and runtime stages
- Updated corresponding image digests to match the new version

## Implementation Details
The new strategy separates update handling by type:
- **Minor/patch production deps**: Fast-tracked with automerge after 3-day soak
- **Major version updates**: Batched to Monday mornings for deliberate review
- **Docker digest-only updates**: Skipped to reduce noise while maintaining security scanning
- **Docker version updates**: Automerged (non-major) with soak period to keep base images current

https://claude.ai/code/session_01HCho88kT562yxGndbQefk1