### PR TITLE
chore(renovate): drop catch-all non-major grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,14 +28,6 @@
   },
   "packageRules": [
     {
-      "description": "Group all non-major dependencies",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "non-major dependencies"
-    },
-    {
       "description": "Group and automerge non-major dev dependencies",
       "matchDepTypes": [
         "dev"


### PR DESCRIPTION
## Summary
- Drop the broad `non-major dependencies` Renovate group so each package not matched by a narrower rule gets its own PR.
- Each package's 3-day `minimumReleaseAge` soak now applies per-PR instead of being short-circuited by the freshest member of a bundle (as happened in #213, which bundled a 1-day-old `anthropic` release with a trivy-action and python docker bump).
- Narrower groupings (`pytest`, `linting tools`, `dev dependencies`, `pre-commit hooks`) are intentionally kept — those bundle tooling that moves together.

## Test plan
- [ ] `validate` (conventional-commits title) passes
- [ ] After merge, next Renovate run recreates #213 as separate PRs (one per package)
- [ ] Confirm `anthropic 0.97.0` PR is created but does not automerge until ~2026-04-26 (3 days after release)

https://claude.ai/code/session_01HCho88kT562yxGndbQefk1

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCho88kT562yxGndbQefk1)_