### PR TITLE
ci: reachability-aware ghcr cleanup (stop breaking multi-arch tags)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,110 +4,39 @@ on:
   schedule:
     - cron: "0 6 * * 0" # Weekly, Sunday 6 AM UTC
   workflow_dispatch: # Allow manual runs
+    inputs:
+      dry_run:
+        description: "Preview deletions without removing anything"
+        type: boolean
+        default: false
 
 permissions:
   packages: write
-
-env:
-  PACKAGE_NAME: volume-price-analysis
-  MIN_VERSIONS_TO_KEEP: 10
 
 jobs:
   prune-images:
     runs-on: ubuntu-latest
     steps:
-      - name: Prune untagged container images
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_OWNER: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-
-          # Validate MIN_VERSIONS_TO_KEEP is a positive integer
-          if ! [[ "${MIN_VERSIONS_TO_KEEP}" =~ ^[0-9]+$ ]] || [ "${MIN_VERSIONS_TO_KEEP}" -lt 1 ]; then
-            echo "::error::MIN_VERSIONS_TO_KEEP must be a positive integer, got: '${MIN_VERSIONS_TO_KEEP}'"
-            exit 1
-          fi
-
-          # Use the user-scoped packages endpoint (not repo-scoped, which 404s for this package)
-          api_base="users/${GH_OWNER}/packages/container/${PACKAGE_NAME}/versions"
-
-          echo "::group::Fetching all package versions"
-          if ! api_output=$(gh api "${api_base}" --paginate 2>&1); then
-            echo "::error::Failed to fetch package versions for '${PACKAGE_NAME}': ${api_output}"
-            exit 1
-          fi
-
-          all_versions=$(echo "${api_output}" | jq -s '[.[][]] | [.[] | {id, created_at, tags: (.metadata.container.tags // [])}]')
-          total=$(echo "${all_versions}" | jq 'length')
-          echo "Found ${total} total version(s)"
-          echo "::endgroup::"
-
-          if [ "${total}" -eq 0 ]; then
-            echo "::warning::No versions found for package '${PACKAGE_NAME}'. Verify the package name and token permissions."
-            echo "### Cleanup Summary" >> "$GITHUB_STEP_SUMMARY"
-            echo "No versions found for package \`${PACKAGE_NAME}\`. No cleanup performed." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          # Filter to untagged versions, sorted oldest-first
-          untagged=$(echo "${all_versions}" | jq '
-            [.[] | select(.tags | length == 0)]
-            | sort_by(.created_at)
-          ')
-          untagged_count=$(echo "${untagged}" | jq 'length')
-          echo "Found ${untagged_count} untagged version(s)"
-
-          # Never delete so many untagged versions that total remaining drops below MIN_VERSIONS_TO_KEEP.
-          # Note: tagged versions are never deleted; only untagged versions are candidates.
-          tagged_count=$((total - untagged_count))
-          max_deletable=$((total - MIN_VERSIONS_TO_KEEP))
-          if [ "${max_deletable}" -lt 0 ]; then
-            max_deletable=0
-          fi
-
-          to_delete=$(echo "${untagged}" | jq --argjson max "${max_deletable}" '.[:$max]')
-          delete_count=$(echo "${to_delete}" | jq 'length')
-
-          if [ "${delete_count}" -eq 0 ]; then
-            echo "Nothing to delete (${tagged_count} tagged, ${untagged_count} untagged, min-keep=${MIN_VERSIONS_TO_KEEP})"
-            echo "### Cleanup Summary" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Deleted**: 0 untagged version(s)" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Remaining**: ${total} version(s)" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          echo "Will delete ${delete_count} of ${untagged_count} untagged version(s) (keeping ${tagged_count} tagged + $((untagged_count - delete_count)) untagged >= ${MIN_VERSIONS_TO_KEEP} total)"
-
-          deleted=0
-          failed=0
-          echo "::group::Deleting versions"
-          while IFS=$'\t' read -r version_id created_at; do
-            [ -z "${version_id}" ] && continue
-            if delete_output=$(gh api --method DELETE "${api_base}/${version_id}" 2>&1); then
-              echo "Deleted version ${version_id} (created ${created_at})"
-              deleted=$((deleted + 1))
-            else
-              echo "::warning::Failed to delete version ${version_id} (created ${created_at}): ${delete_output}"
-              failed=$((failed + 1))
-            fi
-          done < <(echo "${to_delete}" | jq -r '.[] | [(.id | tostring), .created_at] | @tsv')
-          echo "::endgroup::"
-
-          echo "### Cleanup Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Deleted**: ${deleted} untagged version(s)" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${failed}" -gt 0 ]; then
-            echo "- **Failed**: ${failed} version(s)" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          remaining=$((total - deleted))
-          echo -n "- **Remaining**: ${remaining} version(s)" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${failed}" -gt 0 ]; then
-            echo " (includes ${failed} that could not be deleted)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          if [ "${failed}" -gt 0 ]; then
-            echo "::error::Failed to delete ${failed} version(s)"
-            exit 1
-          fi
+      # Reachability-aware pruning. The previous hand-rolled script deleted
+      # untagged versions purely by count (keep newest N), with no awareness of
+      # whether an untagged manifest was still referenced. In a multi-arch image
+      # the tagged :latest/<version> tag points at an index whose per-arch child
+      # manifests (amd64/arm64) and attestation manifests are themselves
+      # untagged. The count-based prune deleted those children once they aged
+      # past the keep window, leaving the tagged index resolvable but its amd64
+      # child returning "manifest unknown" (this is what broke older :latest).
+      #
+      # This action walks every tagged image's manifest list (and referrers), so
+      # an untagged manifest is deleted only when it is NOT a child/referrer of a
+      # tagged image. Tagged versions are never deleted (no delete-tags /
+      # keep-n-tagged set), so a tagged index can never lose a platform child.
+      - name: Prune untagged container images (reachability-aware)
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: volume-price-analysis
+          delete-untagged: true
+          # Informational post-run scan: warns (never fails) if any multi-arch
+          # image is missing platform children. Surfaces pre-existing breakage.
+          validate: true
+          dry-run: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Problem

The weekly `Cleanup` workflow deleted **untagged** ghcr package versions purely by **count** (keep newest `MIN_VERSIONS_TO_KEEP=10`), with no awareness of whether an untagged manifest was still **reachable** from a tag.

Our images are multi-arch (`linux/amd64,linux/arm64`, built by `docker.yml`). A tagged `:latest`/`<version>` tag points at an **OCI image index**; the index's per-arch child manifests (amd64/arm64) and provenance/SBOM **attestation manifests** are themselves **untagged**. Once those children aged past the newest-10 untagged window, the count-based prune deleted them — leaving the tagged index resolvable but its amd64 child returning `manifest unknown`. This silently broke older `:latest` and recurs on every weekly run.

## Evidence (live registry, `ghcr.io/pdemirdjian/volume-price-analysis`)

- Current `:latest` is an OCI index whose 4 referenced manifests **are exactly the 4 untagged versions** in the package: amd64 child `c13a9863`, arm64 child `6192b336`, and two `attestation-manifest` entries (`a426c802`, `1a2b17ca`). They survive today only because they're the newest untagged — the next prune would have deleted them.
- `skopeo inspect --override-arch amd64 :2.5.32` → resolves (`0f6054f2…`). But `:2.5.31`, `:2.5.30`, `:2.5.25`, `:2.5.20`, `:eec027f` → **all already broken** (amd64 child missing). Past runs already destroyed nearly every historical tag's amd64 child.

## Fix

Replace the hand-rolled count-based prune with [`dataaxiom/ghcr-cleanup-action`](https://github.com/dataaxiom/ghcr-cleanup-action) (SHA-pinned to v1.2.2), which is manifest-list + attestation aware:

- `delete-untagged: true` walks each **tagged** image's manifest list and referrers, and deletes an untagged manifest **only when it is not a child/referrer of a tagged image**.
- No `delete-tags`/`keep-n-tagged` is set → tagged versions are never deleted, so a tagged index can no longer lose a platform child.
- `validate: true` adds an informational post-run scan that warns (never fails) if any multi-arch image is missing children — surfaces the pre-existing breakage.
- Adds a `dry_run` `workflow_dispatch` input for safe previews.

## Scope / limitations

This **stops future damage**; it cannot resurrect the already-deleted children of historical tags (those manifests are gone from the registry — a one-way door past runs already walked). `:latest`/`2.5.32` and all future tags stay healthy. Garbage-collecting the already-broken historical tags (`delete-partial-images: true`) is deliberately **not** enabled here — it deletes tagged versions and is a separate decision; can be a follow-up.

## Verification (after merge)

1. `gh workflow run cleanup.yml -f dry_run=true` → confirm it preserves the 4 untagged children of `:latest` (deletes 0 reachable).
2. `gh workflow run cleanup.yml -f dry_run=false` (real run) → then `skopeo inspect --override-arch amd64 :latest` and `:2.5.32` still resolve.

Refs HOM-16 (homelab). The homelab side is already mitigated (morning-briefing pinned to digest `0f6054f2…`); reverting that pin back to `:latest` is an optional follow-up once this is durably healthy.