### PR TITLE
feat(agent): anti-hallucination grounding guardrail for briefings

### DIFF
--- a/src/volume_price_analysis/agent/ai_client.py
+++ b/src/volume_price_analysis/agent/ai_client.py
@@ -7,6 +7,7 @@ Supports multiple providers via the AI_PROVIDER environment variable:
 
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,13 @@ You are a professional options trading analyst writing a morning briefing email.
 
 Your audience is an experienced options trader who wants actionable intelligence,
 not generic advice. Be specific about symbols, scores, levels, and strategies.
+
+GROUNDING (CRITICAL): Use ONLY the tickers, prices, composite scores, and price
+levels present in the structured data provided in the user message. Never invent,
+recall, or guess a symbol, number, or level from memory. Every ticker you mention
+MUST appear in the provided scan results or deep analysis. If a value is not in
+the data, do not state it — say the data is unavailable instead. Do not introduce
+symbols that were not scanned.
 
 IMPORTANT: All analysis is optimized for a **14-day holding period**. Indicator
 periods, expected moves, and strategy suggestions are calibrated for this
@@ -45,6 +53,143 @@ _TRUNCATION_WARNING = (
     "Some candidates or sections may be missing.**"
 )
 
+# Matches a stock-ticker-like token: 1-5 uppercase letters, optionally a leading
+# cashtag ($AAPL) and an optional share-class suffix (BRK.B / BRK-B). Group 1 is
+# the cashtag marker; group 2 is the symbol itself.
+_TICKER_RE = re.compile(r"(\$)?\b([A-Z]{1,5}(?:[.\-][A-Z]{1,2})?)\b")
+
+# Uppercase tokens that legitimately appear in briefings but are NOT tickers.
+# Used to suppress false positives in the grounding check. Covers the indicator
+# vocabulary emitted by indicators.py, common options/trading shorthand, and
+# short English/markdown words that may appear capitalized in headers or prose.
+_NON_TICKER_TOKENS = frozenset(
+    {
+        # Technical indicators / studies
+        "OBV",
+        "VWAP",
+        "VPT",
+        "MFI",
+        "ATR",
+        "HV",
+        "IV",
+        "CMF",
+        "VWMA",
+        "ROC",
+        "DI",
+        "ADX",
+        "ADXR",
+        "RSI",
+        "BB",
+        "AD",
+        "RVOL",
+        "MACD",
+        "EMA",
+        "SMA",
+        "POC",
+        "VA",
+        "VAH",
+        "VAL",
+        "OHLC",
+        "ATL",
+        "ATH",
+        # Options / trading shorthand
+        "DTE",
+        "OTM",
+        "ITM",
+        "ATM",
+        "OI",
+        "PUT",
+        "PUTS",
+        "CALL",
+        "CALLS",
+        "PE",
+        "EPS",
+        "ETF",
+        "ETFS",
+        "YOY",
+        "QOQ",
+        "YTD",
+        "BUY",
+        "SELL",
+        "HOLD",
+        "LONG",
+        "PT",
+        "SL",
+        "TP",
+        "RR",
+        # General / units / time
+        "AI",
+        "CEO",
+        "CFO",
+        "USD",
+        "ET",
+        "EST",
+        "EDT",
+        "UTC",
+        "AM",
+        "PM",
+        "FAQ",
+        "TLDR",
+        "FYI",
+        "Q",
+        # Macro / index / market-structure acronyms (context, not equity picks)
+        "CPI",
+        "PPI",
+        "PCE",
+        "GDP",
+        "PMI",
+        "ISM",
+        "NFP",
+        "FOMC",
+        "FED",
+        "ECB",
+        "BOJ",
+        "BOE",
+        "FX",
+        "VIX",
+        "SPX",
+        "NDX",
+        "DJI",
+        "DJIA",
+        "RUT",
+        "ER",
+        "TTM",
+        "FCF",
+        "ROE",
+        "ROA",
+        "GAAP",
+        # Short English / markdown words that may appear capitalized
+        "AN",
+        "AND",
+        "OR",
+        "THE",
+        "FOR",
+        "TO",
+        "OF",
+        "ON",
+        "AT",
+        "IN",
+        "IS",
+        "BE",
+        "BY",
+        "AS",
+        "IF",
+        "IT",
+        "NO",
+        "SO",
+        "UP",
+        "WE",
+        "US",
+        "TOP",
+        "KEY",
+        "RISK",
+        "LOW",
+        "HIGH",
+        "BULL",
+        "BEAR",
+    }
+)
+
 
 def generate_briefing(
     scan_results: dict,
@@ -72,12 +217,17 @@ def generate_briefing(
     user_content = _build_user_message(scan_results, deep_analyses)
 
     if provider == "anthropic":
-        return _generate_anthropic(user_content, model, api_key)
+        briefing = _generate_anthropic(user_content, model, api_key)
     elif provider == "gemini":
-        return _generate_gemini(user_content, model, api_key)
+        briefing = _generate_gemini(user_content, model, api_key)
     else:
         msg = f"Unknown AI provider: {provider!r}. Use 'gemini' or 'anthropic'."
         raise ValueError(msg)
+
+    # Anti-hallucination guardrail: flag any ticker in the briefing that was not
+    # in the input data. Logs only — the briefing text is never modified.
+    _check_briefing_grounding(briefing, scan_results, deep_analyses)
+    return briefing
 
 
 def _build_user_message(scan_results: dict, deep_analyses: list[dict]) -> str:
@@ -94,6 +244,66 @@ def _build_user_message(scan_results: dict, deep_analyses: list[dict]) -> str:
             user_content += f"```json\n{json.dumps(analysis, indent=2, default=str)}\n```\n\n"
 
     return user_content
+
+
+def _collect_known_symbols(scan_results: dict, deep_analyses: list[dict]) -> set[str]:
+    """Gather every ticker symbol present in the scan/analysis input data.
+
+    Includes candidate setups, errored symbols, and deep-analysis symbols — i.e.
+    every symbol the model was actually shown, normalized to uppercase.
+    """
+    known: set[str] = set()
+    for key in ("high_conviction_setups", "top_bullish", "top_bearish", "errors"):
+        for item in scan_results.get(key) or []:
+            sym = item.get("symbol") if isinstance(item, dict) else None
+            if sym:
+                known.add(str(sym).upper())
+    for item in deep_analyses or []:
+        sym = item.get("symbol") if isinstance(item, dict) else None
+        if sym:
+            known.add(str(sym).upper())
+    return known
+
+
+def _check_briefing_grounding(
+    briefing: str, scan_results: dict, deep_analyses: list[dict]
+) -> list[str]:
+    """Flag ticker-like tokens in the briefing that are absent from the input data.
+
+    A guardrail against LLM hallucination: the briefing must only reference symbols
+    that were actually scanned or analyzed. Any unrecognized symbols are logged at
+    WARNING level and returned (sorted, de-duplicated). The briefing text is never
+    modified — this is a detection/alerting check, not a filter.
+    """
+    # Compare on de-punctuated symbols so share classes (BRK.B / BRK-B) and
+    # dotted abbreviations ("U.S." -> "US") normalize consistently.
+    known = {
+        sym.replace(".", "").replace("-", "")
+        for sym in _collect_known_symbols(scan_results, deep_analyses)
+    }
+    unknown: set[str] = set()
+    for match in _TICKER_RE.finditer(briefing):
+        is_cashtag = bool(match.group(1))
+        token = match.group(2).upper()
+        norm = token.replace(".", "").replace("-", "")
+        if norm in known:
+            continue
+        # Bare single letters in prose ("I", "A", "U.S.") are too noisy to treat
+        # as tickers; only honor them when explicitly cashtagged.
+        if not is_cashtag and len(norm) == 1:
+            continue
+        if not is_cashtag and norm in _NON_TICKER_TOKENS:
+            continue
+        unknown.add(token)
+
+    result = sorted(unknown)
+    if result:
+        logger.warning(
+            "Briefing grounding check: %d unrecognized ticker(s) not in scan data: %s",
+            len(result),
+            ", ".join(result),
+        )
+    return result
 
 
 def _generate_anthropic(user_content: str, model: str, api_key: str) -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,7 +8,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from volume_price_analysis.agent.ai_client import _TRUNCATION_WARNING, generate_briefing
+from volume_price_analysis.agent.ai_client import (
+    _TRUNCATION_WARNING,
+    SYSTEM_PROMPT,
+    _check_briefing_grounding,
+    generate_briefing,
+)
 from volume_price_analysis.agent.config import AgentConfig
 from volume_price_analysis.agent.email_sender import (
     _parse_recipients,
@@ -2057,3 +2062,117 @@ class TestRunMorningBriefingDegradedReturn:
 
         result = await run_morning_briefing(config, dry_run=False, no_ai=False)
         assert result is True
+
+
+class TestBriefingGrounding:
+    """Anti-hallucination grounding check for generated briefings (HOM-38)."""
+
+    @staticmethod
+    def _scan():
+        return {
+            "high_conviction_setups": [{"symbol": "NVDA"}],
+            "top_bullish": [{"symbol": "AAPL"}],
+            "top_bearish": [{"symbol": "TSLA"}],
+            "errors": [{"symbol": "BADX", "error": "no data"}],
+        }
+
+    def test_returns_empty_when_all_tickers_known(self):
+        briefing = "Top pick: AAPL looks bullish. NVDA strong, TSLA bearish."
+        assert _check_briefing_grounding(briefing, self._scan(), []) == []
+
+    def test_flags_hallucinated_ticker(self):
+        briefing = "We also like GOOGL here."
+        assert "GOOGL" in _check_briefing_grounding(briefing, self._scan(), [])
+
+    def test_ignores_indicator_acronyms(self):
+        briefing = (
+            "AAPL shows strong RSI and ADX with low IV. Consider 14-day calls. "
+            "Watch ATR for stops. Volume confirmed via OBV and MFI; check VWAP."
+        )
+        assert _check_briefing_grounding(briefing, self._scan(), []) == []
+
+    def test_ignores_options_and_general_acronyms(self):
+        briefing = "AAPL 14-day calls (DTE). Slightly OTM. AI sentiment positive. US open."
+        assert _check_briefing_grounding(briefing, self._scan(), []) == []
+
+    def test_ignores_macro_and_index_acronyms(self):
+        briefing = (
+            "Market context: CPI and GDP in focus; FOMC midweek. "
+            "VIX low, SPX near resistance. AAPL still the pick."
+        )
+        assert _check_briefing_grounding(briefing, self._scan(), []) == []
+
+    def test_recognizes_deep_analysis_symbols(self):
+        briefing = "MSFT is the standout today."
+        assert _check_briefing_grounding(briefing, self._scan(), [{"symbol": "MSFT"}]) == []
+
+    def test_recognizes_errored_symbols(self):
+        briefing = "BADX could not be analyzed today."
+        assert _check_briefing_grounding(briefing, self._scan(), []) == []
+
+    def test_recognizes_cashtag(self):
+        briefing = "$AAPL is bullish."
+        assert _check_briefing_grounding(briefing, self._scan(), []) == []
+
+    def test_flags_hallucinated_cashtag(self):
+        briefing = "$GOOGL looks great."
+        assert "GOOGL" in _check_briefing_grounding(briefing, self._scan(), [])
+
+    def test_ignores_single_capital_letters_in_prose(self):
+        briefing = "I think AAPL is a buy. U.S. markets are open."
+        assert _check_briefing_grounding(briefing, self._scan(), []) == []
+
+    def test_deduplicates_and_sorts_unknowns(self):
+        briefing = "Buy GOOGL and AMZN. GOOGL again, then AMZN."
+        assert _check_briefing_grounding(briefing, self._scan(), []) == ["AMZN", "GOOGL"]
+
+    def test_handles_missing_scan_keys(self):
+        # errors / high_conviction keys absent should not raise
+        briefing = "AAPL looks good."
+        scan = {"top_bullish": [{"symbol": "AAPL"}]}
+        assert _check_briefing_grounding(briefing, scan, []) == []
+
+    def test_logs_warning_on_mismatch(self, caplog):
+        import logging
+
+        briefing = "We like GOOGL and AMZN."
+        with caplog.at_level(logging.WARNING, logger="volume_price_analysis.agent.ai_client"):
+            _check_briefing_grounding(briefing, self._scan(), [])
+        assert "unrecognized" in caplog.text.lower()
+        assert "GOOGL" in caplog.text
+        assert "AMZN" in caplog.text
+
+    def test_no_warning_when_grounded(self, caplog):
+        import logging
+
+        briefing = "AAPL and NVDA are top picks."
+        with caplog.at_level(logging.WARNING, logger="volume_price_analysis.agent.ai_client"):
+            result = _check_briefing_grounding(briefing, self._scan(), [])
+        assert result == []
+        assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+    def test_system_prompt_has_grounding_clause(self):
+        lowered = SYSTEM_PROMPT.lower()
+        assert "only" in lowered
+        assert "invent" in lowered or "hallucin" in lowered
+
+    def test_generate_briefing_runs_grounding_check(self, mocker, caplog):
+        import logging
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "Buy GOOGL now."  # GOOGL is not in the scan data
+        mock_response.candidates = None
+        mock_client.models.generate_content.return_value = mock_response
+        mocker.patch("google.genai.Client", return_value=mock_client)
+
+        with caplog.at_level(logging.WARNING, logger="volume_price_analysis.agent.ai_client"):
+            result = generate_briefing(
+                scan_results={"top_bullish": [{"symbol": "AAPL"}]},
+                deep_analyses=[],
+                provider="gemini",
+                api_key="test-key",
+            )
+
+        assert "GOOGL" in result  # briefing text is never modified
+        assert "GOOGL" in caplog.text  # but the mismatch is flagged


### PR DESCRIPTION
## Summary
Implements **HOM-38** — the *briefing anti-hallucination guardrail*, serving the "grounded AI output" charter pillar.

Two complementary defenses so the morning briefing only ever references real, scanned symbols:

1. **Prompt-side (prevention).** New `GROUNDING (CRITICAL)` clause in `SYSTEM_PROMPT` instructing the model to use ONLY the tickers, prices, composite scores, and levels present in the input data — never to invent or recall symbols/levels from memory.
2. **Output-side (detection).** A cheap post-generation check (`_check_briefing_grounding`) runs after generation for **both** providers (Gemini + Anthropic). It flags any ticker-like token in the briefing that is absent from the scan/analysis input and logs it at `WARNING`. **The briefing text is never modified** — this is detection/alerting, not filtering.

## How it works
- `_collect_known_symbols` gathers every symbol the model was actually shown: `high_conviction_setups`, `top_bullish`, `top_bearish`, `errors`, and `deep_analyses`.
- A closed-vocabulary validator extracts uppercase ticker-like tokens (1–5 letters, optional `$` cashtag, optional `BRK.B`/`BRK-B` share class) and flags those not in the known set.
- A curated stoplist suppresses non-ticker acronyms the briefing legitimately uses — indicators (`RSI`, `ADX`, `OBV`, `VWAP`, `ATR`…), options/trading (`DTE`, `OTM`, `IV`…), and macro/index (`CPI`, `FOMC`, `GDP`, `VIX`, `SPX`…) — to keep false positives low. Cashtags are always treated as tickers.

## Evidence
Representative spot-check (realistic briefing with macro context):
- **Grounded briefing** (NVDA/AAPL/AMD/TSLA picks + CPI/FOMC/VIX/SPX context) → `[]` (no false positives)
- **Hallucinated briefing** (adds GOOGL, MSFT — not scanned) → `['GOOGL', 'MSFT']` flagged + WARNING logged

## Testing
- 16 new tests in `TestBriefingGrounding`: grounded vs hallucinated, indicator/options/macro acronym suppression, cashtags, errored + deep-analysis symbols, single-letter prose ("U.S."), dedup/sort, WARNING-log assertion, prompt-clause presence, and end-to-end via `generate_briefing`.
- `ai_client.py` at **100%** coverage; full suite **490 passed**, total coverage **95%** (gate 80%).
- `ruff format`, `ruff check`, `mypy src/` all clean.

## Contract safety
Additive only — no MCP tool signature or `generate_briefing` argument changes. Behavior change is limited to one extra log line when a mismatch is detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)