### PR TITLE
fix: harden indicator edge cases (HOM-37)

### DIFF
--- a/src/volume_price_analysis/indicators.py
+++ b/src/volume_price_analysis/indicators.py
@@ -96,6 +96,10 @@ def calculate_volume_profile(data: pd.DataFrame, num_bins: int = 20) -> dict[str
     Returns:
         Dictionary with 'price_levels' and 'volumes' lists
     """
+    if len(data) == 0:
+        # No data -> return a well-formed, all-zero profile (no NaN price levels).
+        return {"price_levels": [0.0] * num_bins, "volumes": [0.0] * num_bins}
+
     min_price = data["Low"].min()
     max_price = data["High"].max()
 
@@ -156,7 +160,8 @@ def calculate_vpt(data: pd.DataFrame) -> pd.Series:
     for i in range(1, len(data)):
         prev_close = data["Close"].iloc[i - 1]
         curr_close = data["Close"].iloc[i]
-        price_change_pct = (curr_close - prev_close) / prev_close
+        # Guard div-by-zero: a zero previous close has no defined pct change -> 0.
+        price_change_pct = (curr_close - prev_close) / prev_close if prev_close != 0 else 0.0
         vpt.append(vpt[-1] + data["Volume"].iloc[i] * price_change_pct)
 
     return pd.Series(vpt, index=data.index)
@@ -205,8 +210,16 @@ def calculate_mfi(data: pd.DataFrame, period: int = 14) -> pd.Series:
     positive_mf = positive_flow.rolling(window=period).sum()
     negative_mf = negative_flow.rolling(window=period).sum()
 
-    mfr = positive_mf / negative_mf
+    # Guard division by zero in the money-flow ratio. Computing the ratio only
+    # where negative_mf > 0 avoids inf/NaN; the two .where() passes then assign
+    # the conventional values for the degenerate windows:
+    #   - negative_mf == 0 with positive flow -> fully overbought (MFI = 100)
+    #   - flat window (no flow either way)     -> neutral (MFI = 50)
+    # Leading insufficient-history values (rolling sum still NaN) stay NaN.
+    mfr = positive_mf / negative_mf.where(negative_mf > 0)
     mfi = 100 - (100 / (1 + mfr))
+    mfi = mfi.where(~((negative_mf == 0) & (positive_mf > 0)), 100.0)
+    mfi = mfi.where(~((negative_mf == 0) & (positive_mf == 0)), 50.0)
 
     return mfi
 
@@ -222,15 +235,33 @@ def analyze_volume_trends(data: pd.DataFrame, window: int = 20) -> dict[str, Any
     Returns:
         Dictionary with volume trend analysis
     """
-    avg_volume = data["Volume"].rolling(window=window).mean()
+    n = len(data)
+    if n == 0:
+        # No data -> safe, well-formed defaults (mirrors detect_volume_breakout).
+        return {
+            "current_volume": 0,
+            "average_volume": 0,
+            "volume_vs_average": "0.00%",
+            "volume_trend": "decreasing",
+            "price_direction": "down",
+            "divergence_detected": False,
+            "divergence_type": "None",
+        }
+
+    # min_periods=1 keeps the average defined when len(data) < window (avoids
+    # int(NaN)); for len(data) >= window the last value is unchanged.
+    avg_volume = data["Volume"].rolling(window=window, min_periods=1).mean()
     current_volume = data["Volume"].iloc[-1]
     current_avg = avg_volume.iloc[-1]
 
     # Calculate volume trend
     volume_increasing = data["Volume"].iloc[-5:].is_monotonic_increasing
 
-    # Calculate price-volume divergence
-    price_direction = "up" if data["Close"].iloc[-1] > data["Close"].iloc[-window] else "down"
+    # Calculate price-volume divergence. Clamp the lookback to available history so
+    # len(data) < window can't IndexError; for len(data) >= window this is exactly
+    # iloc[-window] (unchanged behavior).
+    prior_close = data["Close"].iloc[max(-window, -n)]
+    price_direction = "up" if data["Close"].iloc[-1] > prior_close else "down"
     volume_direction = "up" if current_volume > current_avg else "down"
 
     divergence = (price_direction == "up" and volume_direction == "down") or (
@@ -241,10 +272,15 @@ def analyze_volume_trends(data: pd.DataFrame, window: int = 20) -> dict[str, Any
         f"Price {price_direction}, Volume {volume_direction}" if divergence else "None"
     )
 
+    # Guard against zero average volume (e.g. all-zero volume) -> avoid inf/NaN string.
+    volume_vs_average = (
+        f"{((current_volume / current_avg - 1) * 100):.2f}%" if current_avg else "0.00%"
+    )
+
     return {
         "current_volume": int(current_volume),
         "average_volume": int(current_avg),
-        "volume_vs_average": f"{((current_volume / current_avg - 1) * 100):.2f}%",
+        "volume_vs_average": volume_vs_average,
         "volume_trend": "increasing" if volume_increasing else "decreasing",
         "price_direction": price_direction,
         "divergence_detected": divergence,
@@ -657,9 +693,10 @@ def calculate_enhanced_volume_profile(
         "current_price": float(current_price),
         "position": position,
         "interpretation": interpretation,
-        "poc_distance_pct": float(((current_price / poc) - 1) * 100),
-        "vah_distance_pct": float(((current_price / vah) - 1) * 100),
-        "val_distance_pct": float(((current_price / val) - 1) * 100),
+        # Guard div-by-zero when a level is 0 (e.g. all-zero / degenerate prices).
+        "poc_distance_pct": float(((current_price / poc) - 1) * 100) if poc else 0.0,
+        "vah_distance_pct": float(((current_price / vah) - 1) * 100) if vah else 0.0,
+        "val_distance_pct": float(((current_price / val) - 1) * 100) if val else 0.0,
     }
 
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -3182,3 +3182,138 @@ class TestDetectVolumeBreakoutSingleRow:
         assert result["direction"] == "none"
         assert result["current_volume"] == 1000
         assert result["signal"] == "No breakout"
+
+
+# ============================================================================
+# A6: INDICATOR EDGE-CASE HARDENING (HOM-37)
+#
+# Indicators must degrade gracefully on short / degenerate input instead of
+# raising (IndexError / int(NaN)) or emitting silent garbage (NaN / inf).
+# Additive only: behavior for normal-sized, well-formed inputs is unchanged.
+# ============================================================================
+
+
+class TestAnalyzeVolumeTrendsEdgeCases:
+    """analyze_volume_trends should not crash on short / degenerate input."""
+
+    def test_fewer_rows_than_window_no_crash(self):
+        """len(data) < window must not raise IndexError or int(NaN) ValueError."""
+        data = pd.DataFrame({"Close": [100.0, 101.0, 102.0], "Volume": [1000, 1100, 1200]})
+        result = analyze_volume_trends(data, window=20)
+
+        assert isinstance(result["current_volume"], int)
+        assert isinstance(result["average_volume"], int)
+        assert result["price_direction"] in ("up", "down")
+        assert "%" in result["volume_vs_average"]
+        assert isinstance(result["divergence_detected"], bool)
+
+    def test_zero_average_volume_no_inf(self):
+        """All-zero volume must not yield inf/NaN in the volume_vs_average string."""
+        data = pd.DataFrame({"Close": [100.0] * 25, "Volume": [0] * 25})
+        result = analyze_volume_trends(data, window=20)
+
+        assert result["average_volume"] == 0
+        assert result["current_volume"] == 0
+        assert "inf" not in result["volume_vs_average"].lower()
+        assert "nan" not in result["volume_vs_average"].lower()
+
+    def test_empty_frame_returns_safe_defaults(self):
+        """Empty frame must return safe defaults, not raise."""
+        empty = pd.DataFrame(columns=["Close", "Volume"])
+        result = analyze_volume_trends(empty, window=20)
+
+        assert result["current_volume"] == 0
+        assert result["average_volume"] == 0
+        assert result["divergence_detected"] is False
+
+    def test_sufficient_history_unchanged(self):
+        """Regression guard: len > window keeps the original close[-1] vs close[-window]."""
+        closes = [100.0 + i for i in range(30)]
+        data = pd.DataFrame({"Close": closes, "Volume": [1_000_000] * 30})
+        result = analyze_volume_trends(data, window=20)
+
+        # close[-1]=129 > close[-20]=110 -> "up"
+        assert result["price_direction"] == "up"
+        assert result["average_volume"] == 1_000_000
+
+
+class TestVolumeProfileEmptyFrame:
+    """calculate_volume_profile must not emit NaN price levels for an empty frame."""
+
+    def test_empty_frame_no_nan(self):
+        empty = pd.DataFrame(columns=["High", "Low", "Close", "Volume"])
+        profile = calculate_volume_profile(empty, num_bins=20)
+
+        assert len(profile["price_levels"]) == 20
+        assert len(profile["volumes"]) == 20
+        assert not any(np.isnan(profile["price_levels"]))
+        assert sum(profile["volumes"]) == 0
+
+
+class TestVPTZeroPrevClose:
+    """calculate_vpt must treat a zero previous close as 0% change, not div-by-zero."""
+
+    def test_zero_prev_close_no_inf(self):
+        data = pd.DataFrame({"Close": [0.0, 5.0, 6.0], "Volume": [1000, 1000, 1000]})
+        vpt = calculate_vpt(data)
+
+        assert not np.isinf(vpt).any()
+        assert not vpt.isna().any()
+        assert vpt.iloc[0] == 0
+        # Step 0 -> 5: undefined pct change guarded to 0 -> no contribution
+        assert vpt.iloc[1] == pytest.approx(0.0)
+        # Step 5 -> 6: pct change = 0.2, volume 1000 -> +200
+        assert vpt.iloc[2] == pytest.approx(200.0)
+
+
+class TestMFIFlatWindow:
+    """calculate_mfi must return neutral 50 for a fully flat window, not NaN."""
+
+    def test_flat_typical_price_window_is_neutral(self):
+        data = pd.DataFrame(
+            {
+                "High": [102.0] * 20,
+                "Low": [98.0] * 20,
+                "Close": [100.0] * 20,
+                "Volume": [1_000_000] * 20,
+            }
+        )
+        mfi = calculate_mfi(data, period=14)
+
+        # Warmup region stays NaN; settled flat window -> 50 (neutral)
+        assert mfi.iloc[:13].isna().all()
+        assert mfi.iloc[-1] == pytest.approx(50.0)
+
+    def test_all_positive_flow_window_is_100(self):
+        # Strictly rising typical price -> only positive money flow -> MFI 100
+        data = pd.DataFrame(
+            {
+                "High": [100.0 + i for i in range(20)],
+                "Low": [98.0 + i for i in range(20)],
+                "Close": [99.0 + i for i in range(20)],
+                "Volume": [1_000_000] * 20,
+            }
+        )
+        mfi = calculate_mfi(data, period=14)
+
+        assert mfi.iloc[-1] == pytest.approx(100.0)
+
+
+class TestEnhancedVolumeProfilePOCZero:
+    """calculate_enhanced_volume_profile must guard distance pct when POC/VAH/VAL == 0."""
+
+    def test_zero_price_levels_no_div_by_zero(self):
+        data = pd.DataFrame(
+            {
+                "High": [0.0] * 5,
+                "Low": [0.0] * 5,
+                "Close": [0.0] * 5,
+                "Volume": [1000] * 5,
+            }
+        )
+        result = calculate_enhanced_volume_profile(data)
+
+        assert result["poc"] == 0.0
+        assert result["poc_distance_pct"] == 0.0
+        assert result["vah_distance_pct"] == 0.0
+        assert result["val_distance_pct"] == 0.0


### PR DESCRIPTION
## Summary

A6 indicator edge-case hardening (HOM-37). Adds defensive guards so indicators **degrade gracefully** instead of throwing exceptions or emitting silent `NaN`/`inf` garbage that could propagate into scoring.

All changes are **additive only** — behavior for normal, well-formed, sufficiently-long inputs is unchanged (covered by regression tests). No MCP tool signatures and no scoring/composite logic changed.

## Guards added

| Function | Before | After |
|---|---|---|
| `analyze_volume_trends` | `IndexError` when `len<window`; `int(NaN)` ValueError; `inf%`/`nan%` on zero avg volume | empty-frame safe defaults; `min_periods=1` rolling mean; lookback clamped to history; zero-avg guarded to `0.00%` |
| `calculate_volume_profile` | empty frame returns `NaN` price levels | empty frame returns all-zero, NaN-free profile of correct length |
| `calculate_vpt` | div-by-zero when `prev_close == 0` | treats it as a 0% change |
| `calculate_mfi` | flat window returns `NaN` (0/0) | flat window → neutral `50`; all-positive → `100`; warmup stays `NaN` |
| `calculate_enhanced_volume_profile` | div-by-zero when `poc/vah/val == 0` | `*_distance_pct` guarded to `0.0` |

## Testing

New test classes (one per case): `TestAnalyzeVolumeTrendsEdgeCases`, `TestVolumeProfileEmptyFrame`, `TestVPTZeroPrevClose`, `TestMFIFlatWindow`, `TestEnhancedVolumeProfilePOCZero`. Each was confirmed to **fail on the pre-fix code** (with `RuntimeWarning`s escalated to errors) and pass after.

- `483 passed, 2 skipped`; `indicators.py` at **100%** coverage, 98.01% total (gate ≥80%).
- `ruff check`, `ruff format`, `mypy` all clean.
- Reviewed via the repo's `indicator-validator`: no lookahead bias introduced, math correct (MFI 50/100 conventions verified), additive-only confirmed.

## Out of scope (follow-up)

`calculate_enhanced_volume_profile` still raises `IndexError` on a *truly empty* frame (`data["Close"].iloc[-1]`). Pre-existing, not in HOM-37's listed cases; tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)