### PR TITLE
fix: guard enhanced_volume_profile against empty-frame IndexError

### DIFF
--- a/src/volume_price_analysis/indicators.py
+++ b/src/volume_price_analysis/indicators.py
@@ -603,6 +603,26 @@ def calculate_enhanced_volume_profile(
     Returns:
         Dictionary with POC, VAH, VAL, and full profile data
     """
+    # Empty input has no last close: data["Close"].iloc[-1] below would raise
+    # IndexError, and the delegate calculate_volume_profile yields NaN price
+    # levels for an empty frame. Degrade gracefully to neutral, non-NaN defaults
+    # consistent with the delegate's HOM-37 hardening (see HOM-41).
+    if data.empty:
+        return {
+            "price_levels": [0.0] * num_bins,
+            "volumes": [0.0] * num_bins,
+            "poc": 0.0,
+            "vah": 0.0,
+            "val": 0.0,
+            "value_area_pct": value_area_pct,
+            "current_price": 0.0,
+            "position": "within_value_area",
+            "interpretation": "No price data available",
+            "poc_distance_pct": 0.0,
+            "vah_distance_pct": 0.0,
+            "val_distance_pct": 0.0,
+        }
+
     # Get basic profile
     basic_profile = calculate_volume_profile(data, num_bins)
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1184,6 +1184,32 @@ class TestEnhancedVolumeProfile:
             assert len(result["price_levels"]) == bins
             assert len(result["volumes"]) == bins
 
+    def test_empty_dataframe_returns_safe_defaults(self):
+        """Empty input degrades gracefully to neutral defaults, not IndexError.
+
+        Mirrors the HOM-37 hardening of the delegate calculate_volume_profile,
+        which returns an all-zero profile rather than raising on empty input.
+        """
+        empty_df = pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
+
+        result = calculate_enhanced_volume_profile(empty_df, num_bins=20)
+
+        # Shape contract is preserved (same keys, lists sized to num_bins).
+        assert len(result["price_levels"]) == 20
+        assert len(result["volumes"]) == 20
+        # Safe, non-NaN defaults — no silent garbage.
+        assert result["poc"] == 0.0
+        assert result["vah"] == 0.0
+        assert result["val"] == 0.0
+        assert result["current_price"] == 0.0
+        # No division-by-zero leaking into distance percentages.
+        assert result["poc_distance_pct"] == 0.0
+        assert result["vah_distance_pct"] == 0.0
+        assert result["val_distance_pct"] == 0.0
+        # Neutral position, within the existing enum so consumers don't break.
+        assert result["position"] == "within_value_area"
+        assert result["value_area_pct"] == 0.70
+
 
 class TestADX:
     """Tests for Average Directional Index calculation."""


### PR DESCRIPTION
## Summary

Follow-up from HOM-37. `calculate_enhanced_volume_profile` raised `IndexError` on a **truly empty** DataFrame at `current_price = data["Close"].iloc[-1]`. HOM-37 hardened the delegate `calculate_volume_profile` to degrade gracefully (all-zero profile) for empty input, but the enhanced wrapper still crashed.

This adds an early `data.empty` guard returning **neutral, non-NaN safe defaults**, consistent with the delegate's behavior and the "indicators degrade gracefully, not throw or emit silent garbage" convention.

## What changed

- `indicators.py`: early `data.empty` guard in `calculate_enhanced_volume_profile` returning:
  - `poc`/`vah`/`val`/`current_price` = `0.0`
  - `price_levels`/`volumes` = `[0.0] * num_bins` (clean zeros, not the NaN price levels the delegate emits)
  - `position` = `within_value_area` (neutral, within the existing enum — no new value for consumers to handle)
  - `interpretation` = `"No price data available"` (so the empty state is **signalled, not silent**)
  - distance percentages hard-coded to `0.0` to avoid division by zero
- `test_indicators.py`: `test_empty_dataframe_returns_safe_defaults` asserting the safe-default contract.

## Design notes (per domain lenses)

- **MCP contract stability**: additive only. The returned dict preserves the exact **12-key shape and value types** of the normal path; `position` stays within the existing 3-value enum. No signature or scoring change.
- **Not a silent failure**: the empty condition is surfaced via `interpretation` and `current_price=0.0`, distinguishable from a real reading.
- **No division by zero**: distance percentages are returned as constants rather than computed from `current_price/poc`.

## Verification

- New test fails first with `IndexError: single positional indexer is out-of-bounds` (TDD red), passes after the guard.
- `tests/test_indicators.py`: **236 passed**.
- `ruff check`, `ruff format`, `mypy src/`: all clean.
- Full suite: coverage **94.02%** (gate 80%). The 12 unrelated failures in `test_agent.py` / `test_backtest.py` are pre-existing work-in-progress on the branch and are **not** part of this PR (diff is confined to `indicators.py` + `test_indicators.py`).

Resolves HOM-41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)