### PR TITLE
feat: label volatility as HV proxy and add scan skipped/errors diagnostics (HOM-39)

### DIFF
--- a/src/volume_price_analysis/agent/ai_client.py
+++ b/src/volume_price_analysis/agent/ai_client.py
@@ -22,6 +22,14 @@ timeframe. Make this clear in your strategy suggestions (e.g., "14-day calls"
 not just "calls"). Readers doing shorter-duration plays (e.g., 0-5 DTE) should
 note that signals and levels may not apply to their timeframe.
 
+VOLATILITY HONESTY: The volatility percentile in the data (fields named
+"iv_percentile", "hv_percentile", or "iv_percentile_proxy", basis
+"historical_volatility") is a **Historical Volatility (HV) proxy** computed from
+realized price moves — it is NOT options-market implied volatility (IV). Always
+label it as an HV percentile (e.g., "HV percentile 78% (proxy)") and never
+present it as implied volatility. Frame cheap/expensive options conclusions as
+inferences from HV, not measured IV.
+
 Format the briefing in markdown with clear sections:
 1. **Executive Summary** - 2-3 sentence overview of today's market setup
 2. **Top Picks** - For each high-conviction candidate, include:

--- a/src/volume_price_analysis/analysis.py
+++ b/src/volume_price_analysis/analysis.py
@@ -41,6 +41,18 @@ MAX_CONCURRENT_SCANS = 10
 # Minimum data points required for meaningful Bollinger Band squeeze detection
 MIN_SQUEEZE_DETECTION_PERIODS = 5
 
+# Minimum bars of history required to analyze a symbol in a scan.
+MIN_SCAN_HISTORY = 30
+
+
+class InsufficientDataError(Exception):
+    """Raised when a symbol has too little history to analyze.
+
+    This is a *skip* signal, not a failure: the symbol is excluded from the scan
+    and counted separately from genuine fetch/calculation errors so the scan's
+    diagnostics stay honest about coverage gaps.
+    """
+
 
 def _build_sp500_symbols() -> list[str]:
     """Build S&P 500 symbol list dynamically from pytickersymbols (bundled data, no network)."""
@@ -144,12 +156,13 @@ def analyze_single_symbol(
     """
     Analyze a single symbol for scan_candidates.
 
-    Returns a candidate dict if it passes filters, None otherwise.
-    Raises exception on error.
+    Returns a candidate dict if it passes filters, None if it was analyzed but
+    did not qualify. Raises ``InsufficientDataError`` when there is too little
+    history to analyze (a skip), and propagates other exceptions as errors.
     """
     sym_data = fetch_stock_data(symbol, None, None, period)
-    if len(sym_data) < 30:
-        return None
+    if len(sym_data) < MIN_SCAN_HISTORY:
+        raise InsufficientDataError(f"{symbol}: {len(sym_data)} bars < {MIN_SCAN_HISTORY} required")
 
     # Calculate composite score and key indicators
     composite = calculate_composite_score(sym_data, holding_period)
@@ -188,7 +201,10 @@ def analyze_single_symbol(
         "trend_direction": adx_data["trend_direction"],
         "rsi": round(rsi_data["rsi"], 1),
         "rsi_divergence": rsi_data["divergence_type"],
+        # iv_percentile kept for backward compat; hv_percentile is the honest name
+        # (the value is a historical-volatility proxy, not options-implied vol).
         "iv_percentile": round(iv_pct, 1),
+        "hv_percentile": round(iv_pct, 1),
         "iv_implication": iv_pct_data["options_implication"],
         "expected_move_pct": round(expected_move["expected_move_percent"], 2),
         "rvol": round(rvol["current_rvol"], 2),
@@ -209,11 +225,12 @@ async def _analyze_symbol_async(
     max_iv: float,
     direction: str,
     semaphore: asyncio.Semaphore,
-) -> tuple[str, dict | None, str | None]:
+) -> tuple[str, dict | None, str | None, bool]:
     """
     Async wrapper for symbol analysis with concurrency limiting.
 
-    Returns (symbol, candidate_or_none, error_or_none).
+    Returns (symbol, candidate_or_none, error_or_none, skipped). ``skipped`` is
+    True when the symbol had insufficient history (a non-error skip).
     """
     async with semaphore:
         try:
@@ -227,9 +244,11 @@ async def _analyze_symbol_async(
                 max_iv,
                 direction,
             )
-            return (symbol, result, None)
+            return (symbol, result, None, False)
+        except InsufficientDataError:
+            return (symbol, None, None, True)
         except Exception as e:
-            return (symbol, None, str(e))
+            return (symbol, None, str(e), False)
 
 
 async def run_scan(
@@ -310,20 +329,32 @@ async def run_scan(
         logger.error("Scan timed out after 600 seconds")
         raise ValueError("Scan timed out after 10 minutes") from None
 
-    # Process results
+    # Process results. Each symbol falls into exactly one bucket:
+    #   - error: a genuine fetch/calculation failure
+    #   - skipped: insufficient history to analyze (not a failure)
+    #   - scanned: successfully analyzed (may or may not become a candidate)
     candidates = []
     errors = []
     scanned = 0
+    skipped = 0
 
-    for sym, candidate, error in results:
+    for sym, candidate, error, was_skipped in results:
         if error:
             errors.append({"symbol": sym, "error": error})
+        elif was_skipped:
+            skipped += 1
         else:
             scanned += 1
             if candidate is not None:
                 candidates.append(candidate)
 
-    logger.info("Scan complete: %d candidates from %d scanned", len(candidates), scanned)
+    logger.info(
+        "Scan complete: %d candidates from %d scanned (%d skipped, %d errors)",
+        len(candidates),
+        scanned,
+        skipped,
+        len(errors),
+    )
 
     # Sort by absolute composite score (highest first)
     candidates.sort(key=lambda x: abs(x["composite_score"]), reverse=True)
@@ -349,18 +380,24 @@ async def run_scan(
             "min_adx": min_adx,
             "max_iv_percentile": max_iv_percentile,
             "direction_filter": direction,
+            # iv_percentile / hv_percentile are an HV-based proxy, not options
+            # implied volatility. See indicators.calculate_iv_percentile.
+            "volatility_basis": "historical_volatility",
         },
         "summary": {
             "total_candidates": len(candidates),
             "bullish_setups": len(bullish),
             "bearish_setups": len(bearish),
             "high_conviction": len(high_conviction),
+            # Symbols skipped for insufficient history, distinct from errors.
+            "skipped": skipped,
             "errors": len(errors),
         },
         "high_conviction_setups": high_conviction[:5] if high_conviction else [],
         "top_bullish": bullish[:max_results] if bullish else [],
         "top_bearish": bearish[:max_results] if bearish else [],
-        "errors": errors[:10] if errors else None,
+        # Always a list (capped at 10) so consumers never special-case None.
+        "errors": errors[:10],
     }
 
 
@@ -632,6 +669,9 @@ def run_options_analysis(
         "volatility_analysis": {
             "iv_percentile_proxy": {
                 "percentile": iv_percentile["iv_percentile"],
+                "hv_percentile": iv_percentile["hv_percentile"],
+                "basis": iv_percentile["basis"],
+                "is_proxy": iv_percentile["is_proxy"],
                 "current_hv": iv_percentile["current_hv"],
                 "hv_range": f"{iv_percentile['hv_min']:.1%} - {iv_percentile['hv_max']:.1%}",
                 "interpretation": iv_percentile["interpretation"],
@@ -778,25 +818,27 @@ def _generate_options_insights(
             "Potential reversal down, favor puts"
         )
 
-    # 4. IV Percentile / Volatility Edge
-    iv_pct = iv_percentile["iv_percentile"]
-    if iv_pct > 80:
+    # 4. HV Percentile / Volatility Edge (HV proxy, not options-implied vol)
+    hv_pct = iv_percentile["hv_percentile"]
+    if hv_pct > 80:
         insights.append(
-            f"HIGH IV PERCENTILE ({iv_pct:.0f}%): Options are EXPENSIVE - "
+            f"HIGH HV PERCENTILE ({hv_pct:.0f}%, HV proxy): Options likely EXPENSIVE - "
             f"Favor selling premium (credit spreads, iron condors)"
         )
-    elif iv_pct > 60:
+    elif hv_pct > 60:
         insights.append(
-            f"IV slightly elevated ({iv_pct:.0f}%) - Consider debit spreads to reduce vega risk"
+            f"HV slightly elevated ({hv_pct:.0f}%, HV proxy) - "
+            f"Consider debit spreads to reduce vega risk"
         )
-    elif iv_pct < 20:
+    elif hv_pct < 20:
         insights.append(
-            f"LOW IV PERCENTILE ({iv_pct:.0f}%): Options are CHEAP - "
+            f"LOW HV PERCENTILE ({hv_pct:.0f}%, HV proxy): Options likely CHEAP - "
             f"Great time for long options, straddles, or strangles"
         )
-    elif iv_pct < 40:
+    elif hv_pct < 40:
         insights.append(
-            f"Below-average IV ({iv_pct:.0f}%) - Long directional plays are reasonably priced"
+            f"Below-average HV ({hv_pct:.0f}%, HV proxy) - "
+            f"Long directional plays are reasonably priced"
         )
 
     # 5. Expected Move Guidance

--- a/src/volume_price_analysis/indicators.py
+++ b/src/volume_price_analysis/indicators.py
@@ -933,7 +933,11 @@ def calculate_iv_percentile(
         lookback_days: Days to look back for percentile calculation
 
     Returns:
-        Dictionary with IV percentile proxy data
+        Dictionary with IV percentile proxy data. ``iv_percentile`` is retained
+        for backward compatibility, but the value is derived from historical
+        volatility, NOT options-market implied volatility. The honestly-labeled
+        ``hv_percentile`` carries the same number, with ``basis`` and ``is_proxy``
+        marking it as an HV-based proxy.
     """
     # Calculate rolling HV
     log_returns = (data["Close"] / data["Close"].shift(1)).apply(np.log)
@@ -946,6 +950,9 @@ def calculate_iv_percentile(
         hv_val = hv.iloc[-1]
         return {
             "iv_percentile": 50.0,
+            "hv_percentile": 50.0,
+            "basis": "historical_volatility",
+            "is_proxy": True,
             "current_hv": 0.0 if pd.isna(hv_val) else float(hv_val),  # type: ignore[arg-type]
             "hv_min": 0.0,
             "hv_max": 0.0,
@@ -967,6 +974,11 @@ def calculate_iv_percentile(
     if hv_range > 0:
         iv_percentile = ((current_hv - hv_min) / hv_range) * 100
     else:
+        iv_percentile = 50.0
+
+    # Guard NaN propagation: a NaN current_hv (e.g. a NaN final Close) would make
+    # the percentile NaN. Degrade to a neutral 50.0 rather than leak NaN to callers.
+    if pd.isna(iv_percentile):
         iv_percentile = 50.0
 
     # Interpretation
@@ -993,6 +1005,9 @@ def calculate_iv_percentile(
 
     return {
         "iv_percentile": float(iv_percentile),
+        "hv_percentile": float(iv_percentile),
+        "basis": "historical_volatility",
+        "is_proxy": True,
         "current_hv": 0.0 if pd.isna(current_hv) else float(current_hv),  # type: ignore[arg-type]
         "hv_min": float(hv_min),
         "hv_max": float(hv_max),

--- a/src/volume_price_analysis/server.py
+++ b/src/volume_price_analysis/server.py
@@ -491,7 +491,12 @@ async def handle_list_tools() -> list[Tool]:
                     },
                     "max_iv_percentile": {
                         "type": "number",
-                        "description": "Max IV percentile (default: 100, use 50 for cheap options)",
+                        "description": (
+                            "Max volatility percentile (default: 100, use 50 for cheap "
+                            "options). Note: this is a historical-volatility (HV) proxy, "
+                            "not options-implied volatility; results expose both "
+                            "iv_percentile (compat) and hv_percentile."
+                        ),
                         "default": 100,
                     },
                     "direction": {

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from volume_price_analysis.agent.ai_client import _TRUNCATION_WARNING, generate_briefing
+from volume_price_analysis.agent.ai_client import (
+    _TRUNCATION_WARNING,
+    SYSTEM_PROMPT,
+    generate_briefing,
+)
 from volume_price_analysis.agent.config import AgentConfig
 from volume_price_analysis.agent.email_sender import (
     _parse_recipients,
@@ -2057,3 +2061,17 @@ class TestRunMorningBriefingDegradedReturn:
 
         result = await run_morning_briefing(config, dry_run=False, no_ai=False)
         assert result is True
+
+
+class TestSystemPromptVolatilityLabeling:
+    """The briefing prompt must label volatility honestly as an HV proxy (HOM-39)."""
+
+    def test_prompt_flags_volatility_as_hv_proxy(self):
+        lowered = SYSTEM_PROMPT.lower()
+        assert "historical volatility" in lowered
+        assert "hv" in lowered
+
+    def test_prompt_warns_against_implied_volatility_framing(self):
+        """The prompt must tell the model the metric is not options-implied vol."""
+        lowered = SYSTEM_PROMPT.lower()
+        assert "implied volatility" in lowered

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -4,6 +4,7 @@ import pytest
 
 from volume_price_analysis.analysis import (
     UNIVERSES,
+    InsufficientDataError,
     _build_sp500_symbols,
     analyze_single_symbol,
     run_options_analysis,
@@ -68,6 +69,14 @@ class TestRunOptionsAnalysis:
         assert "options_insights" in result
         assert "latest_price" in result
 
+    def test_iv_percentile_proxy_is_hv_flagged(self, sample_stock_data):
+        """The deep-analysis volatility proxy carries the HV basis + hv_percentile."""
+        result = run_options_analysis("TEST", sample_stock_data, holding_period=14)
+        proxy = result["volatility_analysis"]["iv_percentile_proxy"]
+        assert proxy["basis"] == "historical_volatility"
+        assert proxy["is_proxy"] is True
+        assert proxy["hv_percentile"] == proxy["percentile"]
+
     def test_composite_signal_has_score(self, sample_stock_data):
         result = run_options_analysis("TEST", sample_stock_data)
         signal = result["composite_signal"]
@@ -130,8 +139,8 @@ class TestRunOptionsAnalysis:
 class TestAnalyzeSingleSymbol:
     """Test analyze_single_symbol with mocked data fetching."""
 
-    def test_returns_none_when_insufficient_data(self, mocker):
-        """Should return None when data has fewer than 30 rows."""
+    def test_raises_insufficient_data_when_too_few_rows(self, mocker):
+        """Should raise InsufficientDataError (a 'skip', not an error) for <30 rows."""
         import pandas as pd
 
         small_data = pd.DataFrame(
@@ -149,8 +158,20 @@ class TestAnalyzeSingleSymbol:
             return_value=small_data,
         )
 
-        result = analyze_single_symbol("TEST", "3mo", 14, 2.0, 20, 100, "any")
-        assert result is None
+        with pytest.raises(InsufficientDataError):
+            analyze_single_symbol("TEST", "3mo", 14, 2.0, 20, 100, "any")
+
+    def test_candidate_includes_hv_percentile(self, mocker, sample_stock_data):
+        """A returned candidate carries the honestly-labeled hv_percentile twin."""
+        mocker.patch(
+            "volume_price_analysis.analysis.fetch_stock_data",
+            return_value=sample_stock_data,
+        )
+
+        candidate = analyze_single_symbol("TEST", "3mo", 14, 0, 0, 100, "any")
+        assert candidate is not None
+        assert "hv_percentile" in candidate
+        assert candidate["hv_percentile"] == candidate["iv_percentile"]
 
 
 class TestRunScan:
@@ -230,6 +251,11 @@ class TestRunScan:
         assert "high_conviction_setups" in result
         assert "top_bullish" in result
         assert "top_bearish" in result
+        # HOM-39 additive fields
+        assert result["scan_parameters"]["volatility_basis"] == "historical_volatility"
+        assert isinstance(result["scan_parameters"]["symbols_scanned"], int)
+        assert "skipped" in result["summary"]
+        assert isinstance(result["errors"], list)
 
     @pytest.mark.asyncio
     async def test_scan_handles_errors_gracefully(self, mocker):
@@ -242,6 +268,138 @@ class TestRunScan:
         result = await run_scan(symbols=["BADTICKER"])
         assert result["summary"]["errors"] >= 1
         assert result["summary"]["total_candidates"] == 0
+        # A genuine fetch error is an error, not a skip.
+        assert result["summary"]["skipped"] == 0
+
+    @pytest.mark.asyncio
+    async def test_summary_reports_skipped_count(self, mocker):
+        """Insufficient-data symbols are counted as 'skipped', distinct from errors."""
+        import pandas as pd
+
+        small_data = pd.DataFrame(
+            {
+                "Date": pd.date_range("2024-01-01", periods=10),
+                "Open": [100] * 10,
+                "High": [101] * 10,
+                "Low": [99] * 10,
+                "Close": [100] * 10,
+                "Volume": [1000000] * 10,
+            }
+        )
+        mocker.patch(
+            "volume_price_analysis.analysis.fetch_stock_data",
+            return_value=small_data,
+        )
+
+        result = await run_scan(symbols=["AAA", "BBB", "CCC"])
+        assert result["summary"]["skipped"] == 3
+        assert result["summary"]["errors"] == 0
+        assert result["summary"]["total_candidates"] == 0
+        # Skipped symbols are NOT counted as scanned.
+        assert result["scan_parameters"]["symbols_scanned"] == 0
+
+    @pytest.mark.asyncio
+    async def test_errors_field_is_always_a_list(self, mocker):
+        """The top-level 'errors' field must be a list even when empty (never None)."""
+        import pandas as pd
+
+        small_data = pd.DataFrame(
+            {
+                "Date": pd.date_range("2024-01-01", periods=10),
+                "Open": [100] * 10,
+                "High": [101] * 10,
+                "Low": [99] * 10,
+                "Close": [100] * 10,
+                "Volume": [1000000] * 10,
+            }
+        )
+        mocker.patch(
+            "volume_price_analysis.analysis.fetch_stock_data",
+            return_value=small_data,
+        )
+
+        result = await run_scan(symbols=["AAA"])
+        assert isinstance(result["errors"], list)
+        assert result["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_scan_accounting_is_complete(self, mocker):
+        """scanned + skipped + errors must equal the universe size (honest diagnostics)."""
+        import pandas as pd
+
+        small_data = pd.DataFrame(
+            {
+                "Date": pd.date_range("2024-01-01", periods=10),
+                "Open": [100] * 10,
+                "High": [101] * 10,
+                "Low": [99] * 10,
+                "Close": [100] * 10,
+                "Volume": [1000000] * 10,
+            }
+        )
+
+        def _fetch(symbol, *args, **kwargs):
+            if symbol == "BADX":
+                raise ValueError("No data found")
+            return small_data
+
+        mocker.patch("volume_price_analysis.analysis.fetch_stock_data", side_effect=_fetch)
+
+        result = await run_scan(symbols=["AAA", "BBB", "BADX"])
+        summary = result["summary"]
+        params = result["scan_parameters"]
+        total = params["symbols_scanned"] + summary["skipped"] + summary["errors"]
+        assert total == params["symbols_in_universe"] == 3
+        assert summary["skipped"] == 2
+        assert summary["errors"] == 1
+
+    @pytest.mark.asyncio
+    async def test_all_three_buckets_with_real_candidate(self, mocker):
+        """A scanned candidate, a skip, and an error each land in exactly one bucket."""
+
+        def _analyze(symbol, *args, **kwargs):
+            if symbol == "SMALL":
+                raise InsufficientDataError("SMALL: insufficient history")
+            if symbol == "BADX":
+                raise ValueError("No data found")
+            return {
+                "symbol": symbol,
+                "composite_score": 3.0,
+                "recommendation": "bullish",
+                "signal_quality": "medium",
+                "adx": 25.0,
+                "trend_strength": "moderate",
+                "trend_direction": "up",
+                "rsi": 55.0,
+                "rsi_divergence": "none",
+                "iv_percentile": 40.0,
+                "hv_percentile": 40.0,
+                "iv_implication": "neutral",
+                "expected_move_pct": 3.0,
+                "rvol": 1.2,
+                "latest_price": 100.0,
+                "key_levels": {"upper_target": 103.0, "lower_target": 97.0},
+            }
+
+        mocker.patch("volume_price_analysis.analysis.analyze_single_symbol", side_effect=_analyze)
+
+        result = await run_scan(symbols=["GOOD", "SMALL", "BADX"], min_score=0, min_adx=0)
+        summary = result["summary"]
+        params = result["scan_parameters"]
+
+        assert params["symbols_scanned"] == 1
+        assert summary["skipped"] == 1
+        assert summary["errors"] == 1
+        assert summary["total_candidates"] == 1
+        # Exhaustive, mutually-exclusive accounting.
+        assert (
+            params["symbols_scanned"] + summary["skipped"] + summary["errors"]
+            == params["symbols_in_universe"]
+            == 3
+        )
+        assert [c["symbol"] for c in result["top_bullish"]] == ["GOOD"]
+        assert result["top_bullish"][0]["hv_percentile"] == 40.0
+        assert result["errors"][0]["symbol"] == "BADX"
 
     @pytest.mark.asyncio
     async def test_rejects_too_many_symbols(self):
@@ -291,6 +449,7 @@ class TestRunScan:
                 "rsi": 50.0,
                 "rsi_divergence": "none",
                 "iv_percentile": 50.0,
+                "hv_percentile": 50.0,
                 "iv_implication": "average",
                 "expected_move_pct": 3.0,
                 "rvol": 1.0,

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1674,6 +1674,9 @@ class TestIVPercentile:
 
         expected_keys = {
             "iv_percentile",
+            "hv_percentile",
+            "basis",
+            "is_proxy",
             "current_hv",
             "hv_min",
             "hv_max",
@@ -1683,6 +1686,54 @@ class TestIVPercentile:
             "strategy_suggestion",
         }
         assert expected_keys == set(result.keys())
+
+    def test_hv_percentile_matches_iv_percentile(self):
+        """hv_percentile is the correctly-labeled twin of the iv_percentile proxy."""
+        data = _make_iv_data(n=300)
+        result = calculate_iv_percentile(data)
+
+        assert result["hv_percentile"] == result["iv_percentile"]
+
+    def test_hv_percentile_in_range(self):
+        """hv_percentile must stay within [0, 100] like the proxy it mirrors."""
+        data = _make_iv_data(n=300)
+        result = calculate_iv_percentile(data)
+
+        assert 0 <= result["hv_percentile"] <= 100
+
+    def test_nan_last_close_does_not_leak_nan_percentile(self):
+        """A NaN final Close must degrade to a neutral percentile, never NaN."""
+        data = _make_iv_data(n=300)
+        data.loc[data.index[-1], "Close"] = np.nan
+
+        result = calculate_iv_percentile(data)
+
+        assert not np.isnan(result["iv_percentile"])
+        assert not np.isnan(result["hv_percentile"])
+        assert result["hv_percentile"] == result["iv_percentile"] == 50.0
+
+    def test_basis_is_historical_volatility(self):
+        """The metric basis must be honestly labeled as historical volatility."""
+        data = _make_iv_data(n=300)
+        result = calculate_iv_percentile(data)
+
+        assert result["basis"] == "historical_volatility"
+
+    def test_is_proxy_flag_true(self):
+        """The percentile is an HV-derived proxy, not real implied volatility."""
+        data = _make_iv_data(n=300)
+        result = calculate_iv_percentile(data)
+
+        assert result["is_proxy"] is True
+
+    def test_insufficient_data_includes_honesty_fields(self):
+        """The insufficient-data branch must still carry the proxy/basis labels."""
+        data = _make_large_uptrend(n=25)
+        result = calculate_iv_percentile(data, hv_window=20)
+
+        assert result["hv_percentile"] == result["iv_percentile"] == 50.0
+        assert result["basis"] == "historical_volatility"
+        assert result["is_proxy"] is True
 
     def test_iv_percentile_range(self):
         """Test that IV percentile is between 0 and 100."""


### PR DESCRIPTION
## Summary

Closes the **HOM-39** quick win: fixes a mislabeled headline metric (historical volatility was exposed as `iv_percentile` / *implied* volatility) and adds honest scan diagnostics. **Additive only** — no MCP tool signature or result shape is removed or renamed.

### Output honesty (A2)
- `indicators.calculate_iv_percentile` now returns `hv_percentile` (correctly-named twin of the value), `basis="historical_volatility"`, and `is_proxy=True` in **both** return paths. `iv_percentile` is retained for backward compatibility.
- Scan candidates carry `hv_percentile` alongside `iv_percentile`; `scan_parameters.volatility_basis="historical_volatility"`.
- Deep options analysis `volatility_analysis.iv_percentile_proxy` gains `hv_percentile` / `basis` / `is_proxy`; options-insight text relabeled **IV → HV (proxy)**.
- Briefing `SYSTEM_PROMPT` now instructs the LLM to label volatility as an **HV proxy**, never as implied volatility.
- `scan_candidates` MCP tool: `max_iv_percentile` description clarifies it's an HV proxy.
- **Robustness:** guard NaN percentile propagation (a NaN final `Close` previously leaked `nan` into `iv_percentile`/`hv_percentile`; now degrades to neutral 50.0).

### Scan diagnostics (O5)
- New `InsufficientDataError`: `analyze_single_symbol` raises it for <30 bars (a **skip**, not an error).
- `run_scan` reports a distinct `summary.skipped` count and **always returns a list** for the top-level `errors` field (never `None`).
- `symbols_scanned` now counts analyzed-only symbols, so `scanned + skipped + errors == symbols_in_universe` (exhaustive, mutually-exclusive accounting).

## Verification
- `ruff check` + `ruff format --check`: clean
- `mypy src/`: clean
- **488 passed / 2 skipped**, coverage **98%** (`indicators.py` 100%)
- Ran repo `indicator-validator` and `scan-reviewer` skills; addressed findings (NaN-guard, full-shape mocks, all-three-buckets accounting test, explicit field assertions).

### End-to-end output sample
```
calculate_iv_percentile: iv_percentile=37.6  hv_percentile=37.6  basis=historical_volatility  is_proxy=True
run_scan summary: scanned=2  skipped=1  errors=1  volatility_basis=historical_volatility
  top-level errors -> list = [{'symbol': 'BADX', 'error': 'no data'}]
  accounting: scanned+skipped+errors = 4 == universe 4
  candidate: {'symbol': 'BBB', 'iv_percentile': 39.6, 'hv_percentile': 39.6}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)