### PR TITLE
feat: strictly-causal backtest / evidence harness (HOM-40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,39 @@ ruff check --fix src/ tests/
 mypy src/
 ```
 
+### Evidence Harness (strictly-causal backtest)
+
+`volume_price_analysis.backtest` is an **internal evidence tool** (no MCP
+surface) for measuring the *forward predictive power* of the composite score, so
+scoring changes can be evaluated with before/after numbers instead of intuition.
+
+It is **strictly causal**: the signal at bar `t` is computed by slicing history
+to `data[:t+1]` and calling the existing scorer, so future bars are physically
+absent and cannot leak. The forward return (`Close[t+N]/Close[t] - 1`) is the
+*outcome* only and is never fed back into the signal; a bar is evaluated only
+when its forward bar `t+N` exists. The future-invariance contract is locked by
+`tests/test_backtest.py::test_causal_score_is_invariant_to_future_bars`.
+
+```bash
+# Single symbol, 14-day forward window over 2y of history
+python -m volume_price_analysis.backtest AAPL --period 2y --horizon 14
+
+# Pool several symbols for statistical power; subsample bars to reduce overlap
+python -m volume_price_analysis.backtest AAPL MSFT NVDA SPY --horizon 14 --step 3
+```
+
+It reports, over all evaluated bars: directional hit rate, mean directional
+return (`mean(sign(score) * forward_return)`), Spearman/Pearson IC, and a
+breakdown by score bucket, by `|score|` gate threshold, and for the production
+high-conviction gate (`|score|>=4 & ADX>=28 & IV<=50`). To compare a scoring
+change, run the harness on the same symbols/period before and after and diff the
+reports.
+
+> Caveat: overlapping forward windows are autocorrelated, so single-symbol IC is
+> directional, not conclusive — pool across symbols (and/or use `--step`) for a
+> trustworthy read. Data is ~15-20 min delayed; this measures predictive
+> information, not live tradeability.
+
 ### Environment Management
 
 See [UV_SETUP.md](UV_SETUP.md) for detailed UV usage, or use traditional venv:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,4 @@ override-dependencies = ["curl-cffi>=0.15.0,<0.16"]
 volume-price-analysis = "volume_price_analysis.server:main"
 morning-briefing = "volume_price_analysis.agent.morning_agent:main"
 morning-scheduler = "volume_price_analysis.agent.scheduler:main"
+vpa-backtest = "volume_price_analysis.backtest:main"

--- a/src/volume_price_analysis/backtest.py
+++ b/src/volume_price_analysis/backtest.py
@@ -1,0 +1,455 @@
+"""Strictly-causal backtest / evidence harness for scoring changes.
+
+This module measures the *forward predictive power* of the composite score
+without any lookahead bias, so that scoring changes (e.g. weight tweaks or new
+gate thresholds) can be evaluated with before/after evidence rather than
+intuition.
+
+Design — the no-lookahead guarantee
+-----------------------------------
+The signal at bar ``t`` is computed by **slicing the history to ``data[:t+1]``**
+and calling the existing :func:`calculate_composite_score`. Because future bars
+are *physically absent* from that slice, no indicator can leak them no matter
+what it does internally. The forward return is the *outcome* only and is never
+fed back into the signal; we evaluate a bar only when its forward bar ``t+N``
+exists. See ``tests/test_backtest.py`` for the future-invariance contract tests.
+
+There is **no MCP surface** here — this is an internal evidence tool. It is
+intentionally simple (slice-and-recompute) rather than vectorized, trading
+performance for an airtight causality guarantee.
+
+Realism note: the forward return is measured close-to-close (enter at the close
+of bar ``t`` that produced the signal, exit at the close of ``t+N``). This is the
+standard convention for measuring a signal's predictive information. yfinance
+data is ~15-20 min delayed; this is an analysis tool, not a live-trading model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .data_fetcher import fetch_stock_data
+from .indicators import calculate_composite_score, calculate_iv_percentile
+
+logger = logging.getLogger(__name__)
+
+# IV percentile window used by the production scan (see analysis.analyze_single_symbol).
+_IV_WINDOW = 20
+
+# Score-band buckets matching the product's recommendation labels.
+_SCORE_BUCKETS: tuple[tuple[str, float, float], ...] = (
+    ("strong_bearish", -np.inf, -5.0),
+    ("bearish", -5.0, -2.0),
+    ("neutral", -2.0, 2.0),
+    ("bullish", 2.0, 5.0),
+    ("strong_bullish", 5.0, np.inf),
+)
+
+# High-conviction gate used by run_scan (|score|>=4, ADX>=28, IV<=50).
+_HC_MIN_ABS_SCORE = 4.0
+_HC_MIN_ADX = 28.0
+_HC_MAX_IV = 50.0
+
+
+def forward_returns(data: pd.DataFrame, horizon: int) -> pd.Series:
+    """Close-to-close forward return over ``horizon`` bars, aligned to bar ``t``.
+
+    ``forward_returns[t] = Close[t + horizon] / Close[t] - 1``. The final
+    ``horizon`` bars have no forward bar and are ``NaN`` (never leaked).
+
+    Args:
+        data: DataFrame with a ``Close`` column.
+        horizon: Number of bars to look forward. Must be >= 1.
+
+    Returns:
+        Series of forward returns aligned to the input index.
+    """
+    if horizon < 1:
+        raise ValueError(f"horizon must be >= 1, got {horizon}")
+    close = data["Close"].astype(float)
+    future_close = close.shift(-horizon)
+    return future_close / close - 1.0
+
+
+def causal_score_at(
+    data: pd.DataFrame, bar_index: int, holding_period: int = 14
+) -> dict[str, float]:
+    """Compute the composite-score snapshot *as of* bar ``bar_index``.
+
+    Only data up to and including ``bar_index`` is used — the history is sliced
+    to ``data.iloc[:bar_index + 1]`` before any indicator runs, so future bars
+    cannot influence the result.
+
+    Args:
+        data: Full OHLCV DataFrame.
+        bar_index: Positional index of the bar to evaluate.
+        holding_period: Holding period passed through to the scorer.
+
+    Returns:
+        Dict with ``composite_score``, ``adx`` and ``iv_percentile`` at ``t``.
+
+    Raises:
+        IndexError: If ``bar_index`` is out of range for ``data``.
+    """
+    if bar_index < 0 or bar_index >= len(data):
+        raise IndexError(f"bar_index {bar_index} out of range for data of length {len(data)}")
+
+    window = data.iloc[: bar_index + 1]
+    composite = calculate_composite_score(window, holding_period)
+
+    try:
+        iv_pct = float(calculate_iv_percentile(window, _IV_WINDOW)["iv_percentile"])
+    except Exception:  # pragma: no cover - defensive; IV proxy is a soft gate
+        iv_pct = float("nan")
+
+    return {
+        "composite_score": float(composite["composite_score"]),
+        "adx": float(composite["indicator_summary"]["adx"]),
+        "iv_percentile": iv_pct,
+    }
+
+
+def compute_observations(
+    data: pd.DataFrame,
+    horizon: int,
+    holding_period: int = 14,
+    min_history: int = 50,
+    step: int = 1,
+    symbol: str | None = None,
+) -> pd.DataFrame:
+    """Build the (signal, forward-return) observation set for one symbol.
+
+    For every evaluable bar ``t`` (``t >= min_history - 1`` and a forward bar
+    ``t + horizon`` exists), records the as-of-``t`` composite score and the
+    realized close-to-close forward return.
+
+    Args:
+        data: OHLCV DataFrame with ``Date`` and ``Close`` columns.
+        horizon: Forward-return window in bars.
+        holding_period: Holding period for the scorer's adaptive tuning.
+        min_history: Minimum bars of history before the first evaluable bar
+            (lets indicators warm up).
+        step: Evaluate every ``step``-th bar to reduce overlap between windows.
+        symbol: Optional label stored in a ``symbol`` column.
+
+    Returns:
+        DataFrame with columns ``bar``, ``date``, ``composite_score``, ``adx``,
+        ``iv_percentile``, ``forward_return`` (plus ``symbol`` if provided). Each
+        row's ``forward_return`` is non-NaN by construction.
+    """
+    if horizon < 1:
+        raise ValueError(f"horizon must be >= 1, got {horizon}")
+    if step < 1:
+        raise ValueError(f"step must be >= 1, got {step}")
+
+    n = len(data)
+    fwd = forward_returns(data, horizon).to_numpy()
+    dates = data["Date"].to_numpy() if "Date" in data.columns else np.arange(n)
+
+    first = max(min_history - 1, 0)
+    last = n - 1 - horizon  # last bar with a realized forward return
+
+    rows: list[dict[str, Any]] = []
+    for t in range(first, last + 1, step):
+        snap = causal_score_at(data, t, holding_period)
+        row: dict[str, Any] = {
+            "bar": t,
+            "date": dates[t],
+            "composite_score": snap["composite_score"],
+            "adx": snap["adx"],
+            "iv_percentile": snap["iv_percentile"],
+            "forward_return": float(fwd[t]),
+        }
+        if symbol is not None:
+            row = {"symbol": symbol, **row}
+        rows.append(row)
+
+    columns = ["bar", "date", "composite_score", "adx", "iv_percentile", "forward_return"]
+    if symbol is not None:
+        columns = ["symbol", *columns]
+    return pd.DataFrame(rows, columns=columns)
+
+
+def pool_observations(frames: Iterable[pd.DataFrame]) -> pd.DataFrame:
+    """Concatenate per-symbol observation frames into one pooled set."""
+    frames = [f for f in frames if not f.empty]
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def _ic(scores: pd.Series, fwd: pd.Series, method: str) -> float | None:
+    """Information coefficient (signal/forward-return correlation), or None.
+
+    ``method="spearman"`` is computed as the Pearson correlation of the ranks
+    (the definition of Spearman's rho) to avoid a hard scipy dependency, which
+    pandas' built-in spearman path requires.
+    """
+    if len(scores) < 2:
+        return None
+    a, b = (scores.rank(), fwd.rank()) if method == "spearman" else (scores, fwd)
+    # Correlation is undefined when either series is constant; short-circuit to
+    # avoid a divide-by-zero RuntimeWarning from the underlying numpy call.
+    if a.nunique() < 2 or b.nunique() < 2:
+        return None
+    value = a.corr(b, method="pearson")
+    if value is None or pd.isna(value):
+        return None
+    return float(value)
+
+
+def _directional_stats(scores: np.ndarray, fwd: np.ndarray) -> dict[str, float | int | None]:
+    """Hit rate and directional return for a set of observations."""
+    n = len(scores)
+    if n == 0:
+        return {
+            "n": 0,
+            "hit_rate_directional": None,
+            "mean_directional_return": None,
+            "mean_forward_return": None,
+        }
+    sign = np.sign(scores)
+    directional = sign != 0
+    n_dir = int(directional.sum())
+    hits = (sign == np.sign(fwd)) & directional
+    hit_rate = float(hits.sum() / n_dir) if n_dir > 0 else None
+    return {
+        "n": n,
+        "hit_rate_directional": hit_rate,
+        "mean_directional_return": float(np.mean(sign * fwd)),
+        "mean_forward_return": float(np.mean(fwd)),
+    }
+
+
+def evaluate_observations(
+    obs: pd.DataFrame,
+    gate_thresholds: Sequence[float] = (2.0, 3.0, 4.0, 5.0),
+) -> dict[str, Any]:
+    """Aggregate hit-rate / IC statistics from an observation set.
+
+    Args:
+        obs: Output of :func:`compute_observations` (possibly pooled).
+        gate_thresholds: ``|score|`` cut-offs to evaluate as entry gates.
+
+    Returns:
+        Dict of pooled metrics: overall hit rate, directional return, Spearman
+        and Pearson IC, per-score-bucket stats, per-gate-threshold stats, and the
+        production high-conviction gate (|score|>=4 & ADX>=28 & IV<=50).
+    """
+    if obs.empty:
+        return {
+            "n": 0,
+            "hit_rate_directional": None,
+            "mean_directional_return": None,
+            "mean_forward_return": None,
+            "spearman_ic": None,
+            "pearson_ic": None,
+            "by_score_bucket": [],
+            "by_gate_threshold": [],
+            "high_conviction_gate": _directional_stats(np.array([]), np.array([])),
+        }
+
+    scores = obs["composite_score"].astype(float)
+    fwd = obs["forward_return"].astype(float)
+    scores_np = scores.to_numpy()
+    fwd_np = fwd.to_numpy()
+
+    overall = _directional_stats(scores_np, fwd_np)
+
+    # Score buckets
+    by_bucket: list[dict[str, Any]] = []
+    for name, lo, hi in _SCORE_BUCKETS:
+        if name == "neutral":
+            mask = (scores_np > lo) & (scores_np < hi)
+        elif np.isinf(lo):
+            mask = scores_np <= hi
+        elif np.isinf(hi):
+            mask = scores_np >= lo
+        else:
+            mask = (scores_np > lo) & (scores_np <= hi)
+        stats = _directional_stats(scores_np[mask], fwd_np[mask])
+        by_bucket.append({"bucket": name, **stats})
+
+    # Gate-threshold sweep on |score|
+    by_gate: list[dict[str, Any]] = []
+    for thr in gate_thresholds:
+        mask = np.abs(scores_np) >= thr
+        stats = _directional_stats(scores_np[mask], fwd_np[mask])
+        by_gate.append({"min_abs_score": float(thr), **stats})
+
+    # Production high-conviction gate
+    adx_np = obs["adx"].to_numpy() if "adx" in obs.columns else np.full(len(obs), np.nan)
+    iv_np = (
+        obs["iv_percentile"].to_numpy()
+        if "iv_percentile" in obs.columns
+        else np.full(len(obs), np.nan)
+    )
+    hc_mask = (
+        (np.abs(scores_np) >= _HC_MIN_ABS_SCORE) & (adx_np >= _HC_MIN_ADX) & (iv_np <= _HC_MAX_IV)
+    )
+    high_conviction = _directional_stats(scores_np[hc_mask], fwd_np[hc_mask])
+
+    return {
+        **overall,
+        "spearman_ic": _ic(scores, fwd, "spearman"),
+        "pearson_ic": _ic(scores, fwd, "pearson"),
+        "by_score_bucket": by_bucket,
+        "by_gate_threshold": by_gate,
+        "high_conviction_gate": high_conviction,
+    }
+
+
+def run_symbol_backtest(
+    data: pd.DataFrame,
+    horizon: int,
+    holding_period: int = 14,
+    min_history: int = 50,
+    step: int = 1,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    """Compute observations and evaluate them for a single symbol's data."""
+    obs = compute_observations(data, horizon, holding_period, min_history, step, symbol=symbol)
+    return {"observations": obs, "evaluation": evaluate_observations(obs)}
+
+
+# --------------------------------------------------------------------------- #
+# Reporting / CLI
+# --------------------------------------------------------------------------- #
+
+
+def _fmt_pct(value: float | None) -> str:
+    return "   n/a" if value is None else f"{value * 100:6.2f}%"
+
+
+def _fmt_ic(value: float | None) -> str:
+    return "  n/a" if value is None else f"{value:+.3f}"
+
+
+def format_report(evaluation: dict[str, Any], meta: dict[str, Any]) -> str:
+    """Render an evaluation dict as a readable plain-text report."""
+    lines: list[str] = []
+    lines.append("=" * 68)
+    lines.append("VPA EVIDENCE HARNESS — strictly-causal forward-return read")
+    lines.append("=" * 68)
+    lines.append(
+        f"Symbols: {meta.get('symbols', '?')}   "
+        f"Horizon: {meta.get('horizon', '?')}d   "
+        f"Holding: {meta.get('holding_period', '?')}d   "
+        f"Step: {meta.get('step', 1)}"
+    )
+    lines.append(f"Observations: {evaluation['n']}")
+    lines.append("")
+    lines.append("OVERALL")
+    lines.append(f"  Hit rate (directional) : {_fmt_pct(evaluation['hit_rate_directional'])}")
+    lines.append(f"  Mean forward return    : {_fmt_pct(evaluation['mean_forward_return'])}")
+    lines.append(f"  Mean directional return: {_fmt_pct(evaluation['mean_directional_return'])}")
+    lines.append(f"  Spearman IC            : {_fmt_ic(evaluation['spearman_ic'])}")
+    lines.append(f"  Pearson IC             : {_fmt_ic(evaluation['pearson_ic'])}")
+    lines.append("")
+    lines.append("BY SCORE BUCKET")
+    lines.append(f"  {'bucket':<16}{'n':>6}{'hit':>9}{'dir_ret':>10}{'fwd_ret':>10}")
+    for b in evaluation["by_score_bucket"]:
+        lines.append(
+            f"  {b['bucket']:<16}{b['n']:>6}"
+            f"{_fmt_pct(b['hit_rate_directional']):>9}"
+            f"{_fmt_pct(b['mean_directional_return']):>10}"
+            f"{_fmt_pct(b['mean_forward_return']):>10}"
+        )
+    lines.append("")
+    lines.append("BY GATE THRESHOLD (|score| >=)")
+    lines.append(f"  {'gate':<16}{'n':>6}{'hit':>9}{'dir_ret':>10}{'fwd_ret':>10}")
+    for g in evaluation["by_gate_threshold"]:
+        lines.append(
+            f"  {'|score|>=' + str(g['min_abs_score']):<16}{g['n']:>6}"
+            f"{_fmt_pct(g['hit_rate_directional']):>9}"
+            f"{_fmt_pct(g['mean_directional_return']):>10}"
+            f"{_fmt_pct(g['mean_forward_return']):>10}"
+        )
+    hc = evaluation["high_conviction_gate"]
+    lines.append("")
+    lines.append("HIGH-CONVICTION GATE (|score|>=4 & ADX>=28 & IV<=50)")
+    lines.append(
+        f"  n={hc['n']}  hit={_fmt_pct(hc['hit_rate_directional'])}  "
+        f"dir_ret={_fmt_pct(hc['mean_directional_return'])}  "
+        f"fwd_ret={_fmt_pct(hc['mean_forward_return'])}"
+    )
+    lines.append("=" * 68)
+    return "\n".join(lines)
+
+
+def run_evidence(
+    symbols: Sequence[str],
+    period: str = "2y",
+    horizon: int = 14,
+    holding_period: int = 14,
+    min_history: int = 50,
+    step: int = 1,
+) -> dict[str, Any]:
+    """Fetch data for symbols, compute pooled observations, and evaluate.
+
+    Per-symbol fetch failures are isolated and skipped so one bad symbol does
+    not sink the run.
+    """
+    frames: list[pd.DataFrame] = []
+    errors: list[str] = []
+    for sym in symbols:
+        try:
+            data = fetch_stock_data(sym, None, None, period)
+            obs = compute_observations(data, horizon, holding_period, min_history, step, symbol=sym)
+            if obs.empty:
+                errors.append(f"{sym}: insufficient history")
+            else:
+                frames.append(obs)
+        except Exception as exc:  # isolate per-symbol failures
+            errors.append(f"{sym}: {exc}")
+
+    pooled = pool_observations(frames)
+    evaluation = evaluate_observations(pooled)
+    return {"observations": pooled, "evaluation": evaluation, "errors": errors}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point: ``vpa-backtest AAPL MSFT --horizon 14 --period 2y``."""
+    parser = argparse.ArgumentParser(description="VPA strictly-causal evidence harness")
+    parser.add_argument("symbols", nargs="+", help="Ticker symbol(s) to evaluate")
+    parser.add_argument("--period", default="2y", help="History period (default: 2y)")
+    parser.add_argument("--horizon", type=int, default=14, help="Forward-return window in bars")
+    parser.add_argument("--holding-period", type=int, default=14, help="Scorer holding period")
+    parser.add_argument("--min-history", type=int, default=50, help="Warm-up bars before first")
+    parser.add_argument("--step", type=int, default=1, help="Evaluate every Nth bar")
+    args = parser.parse_args(argv)
+
+    result = run_evidence(
+        args.symbols,
+        period=args.period,
+        horizon=args.horizon,
+        holding_period=args.holding_period,
+        min_history=args.min_history,
+        step=args.step,
+    )
+    print(
+        format_report(
+            result["evaluation"],
+            meta={
+                "symbols": ", ".join(args.symbols),
+                "horizon": args.horizon,
+                "holding_period": args.holding_period,
+                "step": args.step,
+            },
+        )
+    )
+    if result["errors"]:
+        print("\nErrors:")
+        for err in result["errors"]:
+            print(f"  - {err}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/volume_price_analysis/backtest.py
+++ b/src/volume_price_analysis/backtest.py
@@ -28,27 +28,35 @@ from __future__ import annotations
 
 import argparse
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 import numpy as np
 import pandas as pd
 
 from .data_fetcher import fetch_stock_data
-from .indicators import calculate_composite_score, calculate_iv_percentile
+from .indicators import calculate_adx, calculate_composite_score, calculate_iv_percentile
 
 logger = logging.getLogger(__name__)
 
-# IV percentile window used by the production scan (see analysis.analyze_single_symbol).
+# IV percentile window and ADX period used by the production scan
+# (see analysis.analyze_single_symbol). The high-conviction gate must mirror the
+# scan, so the harness uses these same fixed values rather than the scorer's
+# holding-period-adaptive ADX period.
 _IV_WINDOW = 20
+_ADX_PERIOD = 14
 
-# Score-band buckets matching the product's recommendation labels.
-_SCORE_BUCKETS: tuple[tuple[str, float, float], ...] = (
-    ("strong_bearish", -np.inf, -5.0),
-    ("bearish", -5.0, -2.0),
-    ("neutral", -2.0, 2.0),
-    ("bullish", 2.0, 5.0),
-    ("strong_bullish", 5.0, np.inf),
+# Score-band buckets matching the product's recommendation labels. The
+# predicates form an *exact* partition of the score range (no gaps, no overlaps)
+# and mirror calculate_composite_score's recommendation thresholds: a boundary
+# value goes to the more-extreme bucket on its side (e.g. score 2.0 -> bullish,
+# -2.0 -> bearish, 5.0 -> strong_bullish, -5.0 -> strong_bearish).
+_SCORE_BUCKETS: tuple[tuple[str, Callable[[np.ndarray], np.ndarray]], ...] = (
+    ("strong_bearish", lambda s: s <= -5.0),
+    ("bearish", lambda s: (s > -5.0) & (s <= -2.0)),
+    ("neutral", lambda s: (s > -2.0) & (s < 2.0)),
+    ("bullish", lambda s: (s >= 2.0) & (s < 5.0)),
+    ("strong_bullish", lambda s: s >= 5.0),
 )
 
 # High-conviction gate used by run_scan (|score|>=4, ADX>=28, IV<=50).
@@ -73,8 +81,11 @@ def forward_returns(data: pd.DataFrame, horizon: int) -> pd.Series:
     if horizon < 1:
         raise ValueError(f"horizon must be >= 1, got {horizon}")
     close = data["Close"].astype(float)
+    # A zero entry price has no defined return; map it to NaN so it becomes a
+    # dropped (not inf) observation rather than corrupting downstream stats.
+    denom = close.where(close != 0)
     future_close = close.shift(-horizon)
-    return future_close / close - 1.0
+    return future_close / denom - 1.0
 
 
 def causal_score_at(
@@ -103,6 +114,9 @@ def causal_score_at(
     window = data.iloc[: bar_index + 1]
     composite = calculate_composite_score(window, holding_period)
 
+    # ADX and IV come from the same fixed parameters the production scan gates
+    # on (period-14 ADX, 20-bar IV), so the high-conviction gate is faithful.
+    adx = float(calculate_adx(window, _ADX_PERIOD)["adx"])
     try:
         iv_pct = float(calculate_iv_percentile(window, _IV_WINDOW)["iv_percentile"])
     except Exception:  # pragma: no cover - defensive; IV proxy is a soft gate
@@ -110,7 +124,7 @@ def causal_score_at(
 
     return {
         "composite_score": float(composite["composite_score"]),
-        "adx": float(composite["indicator_summary"]["adx"]),
+        "adx": adx,
         "iv_percentile": iv_pct,
     }
 
@@ -157,14 +171,19 @@ def compute_observations(
 
     rows: list[dict[str, Any]] = []
     for t in range(first, last + 1, step):
+        fwd_t = float(fwd[t])
         snap = causal_score_at(data, t, holding_period)
+        # Drop dirty bars: a data gap (NaN Close) can produce a NaN forward
+        # return or a NaN score; never let one leak into the evidence set.
+        if np.isnan(fwd_t) or np.isnan(snap["composite_score"]):
+            continue
         row: dict[str, Any] = {
             "bar": t,
             "date": dates[t],
             "composite_score": snap["composite_score"],
             "adx": snap["adx"],
             "iv_percentile": snap["iv_percentile"],
-            "forward_return": float(fwd[t]),
+            "forward_return": fwd_t,
         }
         if symbol is not None:
             row = {"symbol": symbol, **row}
@@ -205,11 +224,18 @@ def _ic(scores: pd.Series, fwd: pd.Series, method: str) -> float | None:
 
 
 def _directional_stats(scores: np.ndarray, fwd: np.ndarray) -> dict[str, float | int | None]:
-    """Hit rate and directional return for a set of observations."""
+    """Hit rate and directional return for a set of observations.
+
+    ``hit_rate_directional`` and ``mean_directional_return`` are both measured
+    over directional bars only (``score != 0``): a neutral bar takes no position,
+    so including it would dilute the directional metrics. ``mean_forward_return``
+    is the raw mean over all bars (a market-exposure baseline).
+    """
     n = len(scores)
     if n == 0:
         return {
             "n": 0,
+            "n_directional": 0,
             "hit_rate_directional": None,
             "mean_directional_return": None,
             "mean_forward_return": None,
@@ -219,10 +245,12 @@ def _directional_stats(scores: np.ndarray, fwd: np.ndarray) -> dict[str, float |
     n_dir = int(directional.sum())
     hits = (sign == np.sign(fwd)) & directional
     hit_rate = float(hits.sum() / n_dir) if n_dir > 0 else None
+    dir_return = float(np.mean((sign * fwd)[directional])) if n_dir > 0 else None
     return {
         "n": n,
+        "n_directional": n_dir,
         "hit_rate_directional": hit_rate,
-        "mean_directional_return": float(np.mean(sign * fwd)),
+        "mean_directional_return": dir_return,
         "mean_forward_return": float(np.mean(fwd)),
     }
 
@@ -245,6 +273,7 @@ def evaluate_observations(
     if obs.empty:
         return {
             "n": 0,
+            "n_directional": 0,
             "hit_rate_directional": None,
             "mean_directional_return": None,
             "mean_forward_return": None,
@@ -262,17 +291,10 @@ def evaluate_observations(
 
     overall = _directional_stats(scores_np, fwd_np)
 
-    # Score buckets
+    # Score buckets (exact partition via per-bucket predicates)
     by_bucket: list[dict[str, Any]] = []
-    for name, lo, hi in _SCORE_BUCKETS:
-        if name == "neutral":
-            mask = (scores_np > lo) & (scores_np < hi)
-        elif np.isinf(lo):
-            mask = scores_np <= hi
-        elif np.isinf(hi):
-            mask = scores_np >= lo
-        else:
-            mask = (scores_np > lo) & (scores_np <= hi)
+    for name, predicate in _SCORE_BUCKETS:
+        mask = predicate(scores_np)
         stats = _directional_stats(scores_np[mask], fwd_np[mask])
         by_bucket.append({"bucket": name, **stats})
 
@@ -343,7 +365,9 @@ def format_report(evaluation: dict[str, Any], meta: dict[str, Any]) -> str:
         f"Holding: {meta.get('holding_period', '?')}d   "
         f"Step: {meta.get('step', 1)}"
     )
-    lines.append(f"Observations: {evaluation['n']}")
+    lines.append(
+        f"Observations: {evaluation['n']}  (directional: {evaluation.get('n_directional', '?')})"
+    )
     lines.append("")
     lines.append("OVERALL")
     lines.append(f"  Hit rate (directional) : {_fmt_pct(evaluation['hit_rate_directional'])}")

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,396 @@
+"""Tests for the strictly-causal backtest / evidence harness.
+
+The cardinal risk in this module is **lookahead bias**: a signal computed at
+bar ``t`` must depend only on data up to and including ``t``. The headline test
+here (``test_causal_score_is_invariant_to_future_bars``) locks that contract by
+asserting that appending future bars never changes the signal at ``t``.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from volume_price_analysis import backtest
+from volume_price_analysis.backtest import (
+    causal_score_at,
+    compute_observations,
+    evaluate_observations,
+    format_report,
+    forward_returns,
+    main,
+    pool_observations,
+    run_evidence,
+)
+
+
+def _synthetic_data(n: int, seed: int = 7) -> pd.DataFrame:
+    """Deterministic OHLCV data with enough variation to move indicators."""
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range(start="2022-01-01", periods=n, freq="B")
+    # Random-walk close with mild drift so trend/volume indicators vary.
+    steps = rng.normal(0.3, 2.0, size=n)
+    close = 100 + np.cumsum(steps)
+    close = np.maximum(close, 1.0)  # keep prices positive
+    high = close + rng.uniform(0.2, 2.0, size=n)
+    low = close - rng.uniform(0.2, 2.0, size=n)
+    open_ = close - rng.normal(0.0, 1.0, size=n)
+    volume = rng.integers(800_000, 2_000_000, size=n).astype(float)
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": open_,
+            "High": np.maximum.reduce([high, open_, close]),
+            "Low": np.minimum.reduce([low, open_, close]),
+            "Close": close,
+            "Volume": volume,
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# forward_returns
+# --------------------------------------------------------------------------- #
+
+
+def test_forward_returns_matches_definition():
+    data = pd.DataFrame({"Close": [100.0, 110.0, 121.0, 100.0, 50.0]})
+    fr = forward_returns(data, horizon=2)
+    # bar 0: Close[2]/Close[0]-1 = 121/100 - 1 = 0.21
+    assert fr.iloc[0] == pytest.approx(0.21)
+    # bar 1: Close[3]/Close[1]-1 = 100/110 - 1
+    assert fr.iloc[1] == pytest.approx(100 / 110 - 1)
+    # bar 2: Close[4]/Close[2]-1 = 50/121 - 1
+    assert fr.iloc[2] == pytest.approx(50 / 121 - 1)
+
+
+def test_forward_returns_tail_is_nan():
+    """The last ``horizon`` bars have no forward bar and must be NaN."""
+    data = pd.DataFrame({"Close": [100.0, 101.0, 102.0, 103.0, 104.0]})
+    fr = forward_returns(data, horizon=2)
+    assert math.isnan(fr.iloc[-1])
+    assert math.isnan(fr.iloc[-2])
+    assert not math.isnan(fr.iloc[-3])
+
+
+def test_forward_returns_rejects_bad_horizon():
+    data = pd.DataFrame({"Close": [100.0, 101.0]})
+    with pytest.raises(ValueError):
+        forward_returns(data, horizon=0)
+
+
+# --------------------------------------------------------------------------- #
+# causal_score_at — the no-lookahead contract
+# --------------------------------------------------------------------------- #
+
+
+def test_causal_score_is_invariant_to_future_bars():
+    """Signal at bar ``t`` must not change when future bars are added/removed.
+
+    This is the definitive no-lookahead test. We compute the signal at ``t``
+    three ways: on data truncated exactly at ``t``, on data with a handful of
+    future bars, and on the full series. All three must be identical.
+    """
+    data = _synthetic_data(200)
+    t = 120
+
+    snap_minimal = causal_score_at(data.iloc[: t + 1], t, holding_period=14)
+    snap_some_future = causal_score_at(data.iloc[: t + 30], t, holding_period=14)
+    snap_full = causal_score_at(data, t, holding_period=14)
+
+    assert snap_minimal["composite_score"] == snap_full["composite_score"]
+    assert snap_some_future["composite_score"] == snap_full["composite_score"]
+    assert snap_minimal["adx"] == snap_full["adx"]
+    assert snap_minimal["iv_percentile"] == snap_full["iv_percentile"]
+
+
+def test_causal_score_unaffected_by_garbage_future():
+    """Corrupting bars after ``t`` must leave the signal at ``t`` unchanged."""
+    data = _synthetic_data(160)
+    t = 100
+    baseline = causal_score_at(data, t, holding_period=14)
+
+    corrupted = data.copy()
+    corrupted.loc[corrupted.index[t + 1 :], "Close"] *= 5.0
+    corrupted.loc[corrupted.index[t + 1 :], "Volume"] *= 100.0
+    after = causal_score_at(corrupted, t, holding_period=14)
+
+    assert after["composite_score"] == baseline["composite_score"]
+    assert after["adx"] == baseline["adx"]
+
+
+def test_causal_score_out_of_range_raises():
+    data = _synthetic_data(40)
+    with pytest.raises(IndexError):
+        causal_score_at(data, 40, holding_period=14)
+
+
+# --------------------------------------------------------------------------- #
+# compute_observations
+# --------------------------------------------------------------------------- #
+
+
+def test_compute_observations_no_nan_forward_returns():
+    """Every observation must have a realized forward return (no leakage tail)."""
+    data = _synthetic_data(200)
+    obs = compute_observations(data, horizon=10, holding_period=14, min_history=50)
+    assert len(obs) > 0
+    assert obs["forward_return"].notna().all()
+    assert {"date", "composite_score", "adx", "iv_percentile", "forward_return"} <= set(obs.columns)
+
+
+def test_compute_observations_respects_boundaries():
+    """No bar before ``min_history`` and none within ``horizon`` of the end."""
+    data = _synthetic_data(200)
+    horizon, min_history = 14, 60
+    obs = compute_observations(data, horizon=horizon, holding_period=14, min_history=min_history)
+    assert obs["bar"].min() >= min_history - 1
+    assert obs["bar"].max() <= len(data) - 1 - horizon
+
+
+def test_compute_observations_forward_return_matches_close():
+    data = _synthetic_data(120)
+    horizon = 7
+    obs = compute_observations(data, horizon=horizon, holding_period=14, min_history=50)
+    close = data["Close"].to_numpy()
+    for _, row in obs.iterrows():
+        t = int(row["bar"])
+        expected = close[t + horizon] / close[t] - 1
+        assert row["forward_return"] == pytest.approx(expected)
+
+
+def test_compute_observations_score_invariant_to_truncation():
+    """Observations shared between full and truncated runs must match exactly.
+
+    This is the no-lookahead contract at the dataset level: truncating future
+    bars must not change any already-evaluable observation's score.
+    """
+    data = _synthetic_data(220)
+    obs_full = compute_observations(data, horizon=5, holding_period=14, min_history=50)
+    obs_trunc = compute_observations(data.iloc[:160], horizon=5, holding_period=14, min_history=50)
+    merged = obs_full.merge(obs_trunc, on="bar", suffixes=("_full", "_trunc"))
+    assert len(merged) > 0
+    pd.testing.assert_series_equal(
+        merged["composite_score_full"],
+        merged["composite_score_trunc"],
+        check_names=False,
+    )
+
+
+def test_compute_observations_step_subsamples():
+    data = _synthetic_data(200)
+    obs_all = compute_observations(data, horizon=5, holding_period=14, min_history=50, step=1)
+    obs_step = compute_observations(data, horizon=5, holding_period=14, min_history=50, step=3)
+    assert len(obs_step) < len(obs_all)
+    # stepped bars are a subset spaced by `step`
+    bars = obs_step["bar"].to_numpy()
+    assert np.all(np.diff(bars) == 3)
+
+
+def test_compute_observations_insufficient_history_returns_empty():
+    data = _synthetic_data(20)
+    obs = compute_observations(data, horizon=5, holding_period=14, min_history=50)
+    assert len(obs) == 0
+
+
+def test_compute_observations_rejects_bad_horizon_and_step():
+    data = _synthetic_data(60)
+    with pytest.raises(ValueError):
+        compute_observations(data, horizon=0)
+    with pytest.raises(ValueError):
+        compute_observations(data, horizon=5, step=0)
+
+
+# --------------------------------------------------------------------------- #
+# evaluate_observations
+# --------------------------------------------------------------------------- #
+
+
+def _obs(scores, fwd, adx=None, iv=None) -> pd.DataFrame:
+    n = len(scores)
+    return pd.DataFrame(
+        {
+            "bar": range(n),
+            "date": pd.date_range("2023-01-01", periods=n, freq="B"),
+            "composite_score": scores,
+            "adx": adx if adx is not None else [30.0] * n,
+            "iv_percentile": iv if iv is not None else [40.0] * n,
+            "forward_return": fwd,
+        }
+    )
+
+
+def test_evaluate_hit_rate_perfect():
+    # score sign always matches forward-return sign -> hit rate 1.0
+    obs = _obs([5, -5, 3, -3], [0.02, -0.01, 0.05, -0.04])
+    res = evaluate_observations(obs)
+    assert res["hit_rate_directional"] == pytest.approx(1.0)
+    assert res["n"] == 4
+
+
+def test_evaluate_hit_rate_inverted():
+    # score sign always opposes forward-return sign -> hit rate 0.0
+    obs = _obs([5, -5, 3, -3], [-0.02, 0.01, -0.05, 0.04])
+    res = evaluate_observations(obs)
+    assert res["hit_rate_directional"] == pytest.approx(0.0)
+
+
+def test_evaluate_directional_return_is_signed_mean():
+    scores = [4, -4, 2]
+    fwd = [0.03, -0.02, 0.01]
+    obs = _obs(scores, fwd)
+    res = evaluate_observations(obs)
+    expected = np.mean([np.sign(s) * f for s, f in zip(scores, fwd, strict=True)])
+    assert res["mean_directional_return"] == pytest.approx(expected)
+
+
+def test_evaluate_ic_monotonic_positive():
+    scores = list(range(-5, 6))
+    fwd = [s * 0.01 for s in scores]  # perfectly rank-correlated
+    obs = _obs(scores, fwd)
+    res = evaluate_observations(obs)
+    assert res["spearman_ic"] == pytest.approx(1.0)
+    assert res["pearson_ic"] == pytest.approx(1.0)
+
+
+def test_evaluate_ic_monotonic_negative():
+    scores = list(range(-5, 6))
+    fwd = [-s * 0.01 for s in scores]
+    obs = _obs(scores, fwd)
+    res = evaluate_observations(obs)
+    assert res["spearman_ic"] == pytest.approx(-1.0)
+
+
+def test_evaluate_degenerate_inputs():
+    # zero-variance scores -> IC undefined (None), no crash
+    obs = _obs([0, 0, 0, 0], [0.01, -0.02, 0.03, 0.0])
+    res = evaluate_observations(obs)
+    assert res["spearman_ic"] is None
+    assert res["pearson_ic"] is None
+    # empty -> graceful zeros/None
+    empty = _obs([], [])
+    res_empty = evaluate_observations(empty)
+    assert res_empty["n"] == 0
+    assert res_empty["hit_rate_directional"] is None
+
+
+def test_evaluate_score_buckets_partition():
+    scores = [-6, -3, 0, 3, 6, 1]
+    fwd = [-0.01, -0.02, 0.0, 0.03, 0.05, 0.01]
+    obs = _obs(scores, fwd)
+    res = evaluate_observations(obs)
+    counts = {b["bucket"]: b["n"] for b in res["by_score_bucket"]}
+    assert counts["strong_bearish"] == 1
+    assert counts["bearish"] == 1
+    assert counts["neutral"] == 2  # scores 0 and 1
+    assert counts["bullish"] == 1
+    assert counts["strong_bullish"] == 1
+    assert sum(b["n"] for b in res["by_score_bucket"]) == 6
+
+
+def test_evaluate_gate_thresholds_monotone():
+    scores = [1, 2, 3, 4, 5, -2, -4]
+    fwd = [0.0, 0.01, 0.02, 0.03, 0.04, -0.01, -0.03]
+    obs = _obs(scores, fwd)
+    res = evaluate_observations(obs, gate_thresholds=(2, 3, 4))
+    gates = {g["min_abs_score"]: g["n"] for g in res["by_gate_threshold"]}
+    # stricter gate -> fewer or equal observations pass
+    assert gates[2] >= gates[3] >= gates[4]
+    assert gates[2] == 6  # |score| >= 2: 2, 3, 4, 5, -2, -4
+    assert gates[4] == 3  # |score| >= 4: 4, 5, -4
+
+
+def test_evaluate_high_conviction_gate():
+    # Only the first row clears |score|>=4 AND adx>=28 AND iv<=50
+    obs = _obs(
+        scores=[5, 5, 1],
+        fwd=[0.04, 0.03, 0.0],
+        adx=[30.0, 20.0, 30.0],
+        iv=[40.0, 40.0, 40.0],
+    )
+    res = evaluate_observations(obs)
+    hc = res["high_conviction_gate"]
+    assert hc["n"] == 1
+    assert hc["mean_directional_return"] == pytest.approx(0.04)
+
+
+# --------------------------------------------------------------------------- #
+# pooling + reporting
+# --------------------------------------------------------------------------- #
+
+
+def test_pool_observations_concatenates():
+    a = _obs([1, 2], [0.01, 0.02])
+    a.insert(0, "symbol", "AAA")
+    b = _obs([3], [0.03])
+    b.insert(0, "symbol", "BBB")
+    pooled = pool_observations([a, b])
+    assert len(pooled) == 3
+    assert set(pooled["symbol"]) == {"AAA", "BBB"}
+
+
+def test_format_report_contains_key_metrics():
+    obs = _obs([5, -5, 3, -3], [0.02, -0.01, 0.05, -0.04])
+    res = evaluate_observations(obs)
+    report = format_report(res, meta={"symbols": "TEST", "horizon": 10, "holding_period": 14})
+    assert "Hit rate" in report
+    assert "IC" in report
+    assert "TEST" in report
+
+
+def test_pool_observations_empty_returns_empty():
+    assert pool_observations([]).empty
+
+
+# --------------------------------------------------------------------------- #
+# run_evidence + main (orchestration; fetch is monkeypatched, no network)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_fetch_factory(monkeypatch):
+    """Patch fetch_stock_data: known good symbols return data, others raise."""
+
+    def fake_fetch(symbol, start, end, period):
+        if symbol == "BAD":
+            raise ValueError("no data found for BAD")
+        if symbol == "SHORT":
+            return _synthetic_data(20)  # too little history -> empty observations
+        return _synthetic_data(200, seed=hash(symbol) % 1000)
+
+    monkeypatch.setattr(backtest, "fetch_stock_data", fake_fetch)
+
+
+def test_run_evidence_isolates_per_symbol_failures(monkeypatch):
+    """One bad symbol must not sink the run; good symbols still pool."""
+    _fake_fetch_factory(monkeypatch)
+    result = run_evidence(["GOOD", "BAD"], period="2y", horizon=10, min_history=50)
+    assert result["evaluation"]["n"] > 0
+    assert any("BAD" in e for e in result["errors"])
+    # pooled observations carry the contributing symbol
+    assert "GOOD" in set(result["observations"]["symbol"])
+    assert "BAD" not in set(result["observations"]["symbol"])
+
+
+def test_run_evidence_records_insufficient_history(monkeypatch):
+    _fake_fetch_factory(monkeypatch)
+    result = run_evidence(["SHORT"], period="2y", horizon=10, min_history=50)
+    assert result["evaluation"]["n"] == 0
+    assert any("insufficient history" in e for e in result["errors"])
+
+
+def test_run_evidence_pools_multiple_symbols(monkeypatch):
+    _fake_fetch_factory(monkeypatch)
+    one = run_evidence(["GOOD"], period="2y", horizon=10, min_history=50)
+    two = run_evidence(["GOOD", "ALSO"], period="2y", horizon=10, min_history=50)
+    assert two["evaluation"]["n"] > one["evaluation"]["n"]
+
+
+def test_main_prints_report_and_returns_zero(monkeypatch, capsys):
+    _fake_fetch_factory(monkeypatch)
+    rc = main(["GOOD", "BAD", "--period", "2y", "--horizon", "10", "--min-history", "50"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "VPA EVIDENCE HARNESS" in out
+    assert "Errors:" in out  # BAD failure surfaced
+    assert "BAD" in out

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -344,6 +344,72 @@ def test_pool_observations_empty_returns_empty():
 
 
 # --------------------------------------------------------------------------- #
+# Correctness fixes from review (causality-adjacent quant bugs)
+# --------------------------------------------------------------------------- #
+
+
+def test_mean_directional_return_excludes_neutral():
+    """Neutral (score==0) bars take no position and must not dilute dir return."""
+    obs = _obs([4, 0], [0.02, 0.10])
+    res = evaluate_observations(obs)
+    assert res["mean_directional_return"] == pytest.approx(0.02)  # only the score=4 bar
+    assert res["mean_forward_return"] == pytest.approx(0.06)  # raw mean over all bars
+    assert res["hit_rate_directional"] == pytest.approx(1.0)
+    assert res["n"] == 2
+    assert res["n_directional"] == 1
+
+
+def test_score_buckets_exact_partition_at_boundaries():
+    """Boundary scores (+/-2, +/-5) must each land in exactly one bucket.
+
+    Each score gets a unique forward return (score/100) so we can assert the
+    *right* score is in each bucket — not just that the counts happen to total
+    correctly (a dropped 2.0 and a double-counted 5.0 cancel in the total).
+    """
+    scores = [-5, -2, 0, 2, 5]
+    obs = _obs(scores, [s / 100 for s in scores])
+    res = evaluate_observations(obs)
+    by = {b["bucket"]: b for b in res["by_score_bucket"]}
+    assert by["strong_bearish"]["n"] == 1 and by["strong_bearish"][
+        "mean_forward_return"
+    ] == pytest.approx(-0.05)
+    assert by["bearish"]["n"] == 1 and by["bearish"]["mean_forward_return"] == pytest.approx(-0.02)
+    assert by["neutral"]["n"] == 1 and by["neutral"]["mean_forward_return"] == pytest.approx(0.0)
+    assert by["bullish"]["n"] == 1 and by["bullish"]["mean_forward_return"] == pytest.approx(0.02)
+    assert by["strong_bullish"]["n"] == 1 and by["strong_bullish"][
+        "mean_forward_return"
+    ] == pytest.approx(0.05)
+    assert sum(b["n"] for b in res["by_score_bucket"]) == 5  # exact partition
+
+
+def test_causal_score_adx_matches_production_period_14():
+    """High-conviction gate mirrors the scan, which gates on period-14 ADX."""
+    from volume_price_analysis.indicators import calculate_adx
+
+    data = _synthetic_data(120)
+    t = 100
+    snap = causal_score_at(data, t, holding_period=14)
+    expected = calculate_adx(data.iloc[: t + 1], 14)["adx"]
+    assert snap["adx"] == pytest.approx(expected)
+
+
+def test_compute_observations_drops_dirty_bars():
+    """A NaN Close (data gap) must never leak a NaN into the observation set."""
+    data = _synthetic_data(160)
+    data.loc[data.index[100], "Close"] = np.nan
+    obs = compute_observations(data, horizon=5, holding_period=14, min_history=50)
+    assert len(obs) > 0
+    assert obs["forward_return"].notna().all()
+    assert obs["composite_score"].notna().all()
+
+
+def test_forward_returns_zero_close_is_nan_not_inf():
+    data = pd.DataFrame({"Close": [0.0, 100.0, 110.0]})
+    fr = forward_returns(data, horizon=1)
+    assert math.isnan(fr.iloc[0])  # 100/0 must be NaN, not inf
+
+
+# --------------------------------------------------------------------------- #
 # run_evidence + main (orchestration; fetch is monkeypatched, no network)
 # --------------------------------------------------------------------------- #
 

--- a/uv.lock
+++ b/uv.lock
@@ -1314,7 +1314,7 @@ wheels = [
 
 [[package]]
 name = "volume-price-analysis-mcp"
-version = "2.5.31"
+version = "2.5.32"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What & why

Adds `volume_price_analysis.backtest`, an **internal evidence harness** (no MCP
surface) that measures the *forward predictive power* of the composite score, so
upcoming scoring changes (the A1/A3/A4/A5 quality track) can be judged on
before/after numbers instead of intuition. Enabler task **HOM-40** on the VPA
roadmap.

## No-lookahead by construction (the cardinal risk)

The signal at bar `t` is computed by **slicing history to `data[:t+1]`** and
calling the existing `calculate_composite_score`. Future bars are *physically
absent* from that slice, so no indicator can leak them regardless of its
internals. The forward return (`Close[t+N]/Close[t]-1`) is the *outcome* only and
never feeds the signal; a bar is evaluated only when its forward bar `t+N` exists.

Two contract tests lock this:
- `test_causal_score_is_invariant_to_future_bars` — signal at `t` identical whether computed on `data[:t+1]`, with extra future bars, or the full series.
- `test_causal_score_unaffected_by_garbage_future` — corrupting bars after `t` (×5 price, ×100 volume) leaves the signal at `t` unchanged.

## What it reports

Over all evaluated bars: directional hit rate, mean directional return
(`mean(sign(score)·fwd)` over directional bars only), Spearman/Pearson IC
(Spearman computed scipy-free as Pearson-of-ranks), plus breakdowns by score
bucket (exact partition), by `|score|` gate threshold, and the production
high-conviction gate (`|score|≥4 & ADX≥28 & IV≤50`, using the scan's fixed
period-14 ADX). Per-symbol fetch failures are isolated so one bad symbol can't
sink a pooled run.

Run it: `python -m volume_price_analysis.backtest AAPL --period 2y --horizon 14`
or `vpa-backtest AAPL MSFT --horizon 14 --step 3`.

## First real-data read (2y, 14d horizon)

Pooled across AAPL/SPY/MSFT/NVDA (1,752 obs): overall directional hit 50.9%,
Spearman IC **−0.09**. Buckets show **bearish signals are anti-predictive in this
bull-run sample** (bearish hit 32%, dir_ret −3.1%) while the bullish side
rank-orders returns. The standout is the **production high-conviction gate:
88.9% directional hit, +2.67%** over 14d — but very rare (9/1,752). This is the
baseline A1 should aim to beat. (Caveats: single bull regime, 4 mega-caps,
overlapping windows → directional, not conclusive.)

## Tests / gates
- 34 new tests in `tests/test_backtest.py`; `backtest.py` at 98% coverage
- `ruff` + `mypy` clean; full suite 508 passed, total coverage 97.97%
- Includes 5 bug-reproduction tests from a scan-reviewer pass (bucket partition, directional-return dilution, ADX-period faithfulness, dirty-bar/zero-price robustness)

## Scope notes
- Additive only — no MCP tool signatures touched.
- New optional console script `vpa-backtest`; `uv.lock` syncs local version 2.5.31→2.5.32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
