### PR TITLE
feat: ground briefing output and flag hallucinated tickers (HOM-45)

### DIFF
--- a/src/volume_price_analysis/agent/ai_client.py
+++ b/src/volume_price_analysis/agent/ai_client.py
@@ -7,6 +7,7 @@ Supports multiple providers via the AI_PROVIDER environment variable:
 
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,13 @@ You are a professional options trading analyst writing a morning briefing email.
 
 Your audience is an experienced options trader who wants actionable intelligence,
 not generic advice. Be specific about symbols, scores, levels, and strategies.
+
+GROUNDING (CRITICAL): Use ONLY the tickers, prices, composite scores, key levels,
+and indicator readings that appear in the data provided below. Every ticker symbol
+you name MUST come from the scan results or deep-analysis data. Never invent,
+guess, infer, or substitute a symbol, price, or level that is not present in the
+input. If the data does not contain something, say so plainly instead of filling
+the gap. Do not add tickers from memory or general market knowledge.
 
 IMPORTANT: All analysis is optimized for a **14-day holding period**. Indicator
 periods, expected moves, and strategy suggestions are calibrated for this
@@ -53,6 +61,224 @@ _TRUNCATION_WARNING = (
     "Some candidates or sections may be missing.**"
 )
 
+# Uppercase tokens that look like tickers but are domain acronyms or common
+# words. Used to keep the anti-hallucination check high-precision (few false
+# positives) so its warnings stay meaningful. This is a best-effort denylist for
+# a logging guard, not a security boundary — a token here is simply never flagged
+# as a hallucinated ticker, even if some entries (e.g. "DD", "IPO") happen to
+# collide with real symbols.
+_NON_TICKER_TOKENS: frozenset[str] = frozenset(
+    {
+        # Indicator / options acronyms emitted throughout the analysis output.
+        "ADX",
+        "RSI",
+        "VWAP",
+        "VWMA",
+        "OBV",
+        "MFI",
+        "CMF",
+        "ATR",
+        "POC",
+        "VAH",
+        "VAL",
+        "IV",
+        "HV",
+        "DTE",
+        "ROC",
+        "VPT",
+        "DI",
+        "EMA",
+        "SMA",
+        "MACD",
+        "ATM",
+        "OTM",
+        "ITM",
+        "PCR",
+        "BB",
+        "STD",
+        "EM",
+        "ADL",
+        "OI",
+        # Direction / strategy / emphasis words the model may capitalize.
+        "BULLISH",
+        "BEARISH",
+        "NEUTRAL",
+        "STRONG",
+        "WEAK",
+        "HIGH",
+        "LOW",
+        "NO",
+        "YES",
+        "TREND",
+        "EXTREME",
+        "VOLUME",
+        "BREAKOUT",
+        "SQUEEZE",
+        "EXPECTED",
+        "MOVE",
+        "WARNING",
+        "URGENT",
+        "BUY",
+        "SELL",
+        "HOLD",
+        "LONG",
+        "SHORT",
+        "CALL",
+        "CALLS",
+        "PUT",
+        "PUTS",
+        "RISK",
+        "ALERT",
+        "WATCH",
+        "NOTE",
+        "KEY",
+        "TARGET",
+        "ENTRY",
+        "EXIT",
+        "STOP",
+        "GAIN",
+        "LOSS",
+        # Generic English / market abbreviations.
+        "A",
+        "I",
+        "AN",
+        "THE",
+        "AND",
+        "OR",
+        "IF",
+        "IS",
+        "IT",
+        "TO",
+        "IN",
+        "ON",
+        "AT",
+        "BY",
+        "OF",
+        "AS",
+        "BE",
+        "US",
+        "USD",
+        "ETF",
+        "ETFS",
+        "AI",
+        "PM",
+        "AM",
+        "EST",
+        "EDT",
+        "PST",
+        "PDT",
+        "UTC",
+        "GMT",
+        "EOD",
+        "EPS",
+        "PE",
+        "YOY",
+        "QOQ",
+        "FY",
+        "Q",
+        "S",
+        "P",
+        "E",
+        "R",
+        "U",
+        "N",
+        "OK",
+        "NA",
+        "TBD",
+        "FAQ",
+        "CEO",
+        "CFO",
+        "FOMC",
+        "FED",
+        "GDP",
+        "CPI",
+        "DAY",
+        "DAYS",
+        "WEEK",
+        "VS",
+        "VIA",
+        "PER",
+        "MAX",
+        "MIN",
+        "AVG",
+        "ETC",
+        "ROI",
+        "SEC",
+        "IPO",
+        "ATH",
+        "YTD",
+        "EV",
+        "ER",
+        "PT",
+        "SL",
+        "TP",
+        "DD",
+    }
+)
+
+# Matches a ticker-shaped token: an optional "$" cashtag, 1-5 uppercase letters,
+# and an optional class-share suffix (e.g. BRK.B / BRK-B). Lookarounds prevent
+# matching letters embedded in mixed-case words (e.g. the "P" in "iPhone").
+_TICKER_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9.])(\$?)([A-Z]{1,5})(?:[.\-]([A-Z]{1,2}))?(?![A-Za-z0-9])"
+)
+
+
+def _normalize_symbol(symbol: str) -> str:
+    """Uppercase and strip class-share separators for comparison (BRK.B -> BRKB)."""
+    return re.sub(r"[^A-Z]", "", symbol.upper())
+
+
+def _collect_input_symbols(scan_results: dict, deep_analyses: list[dict]) -> set[str]:
+    """Collect every ticker symbol present anywhere in the scan/analysis input.
+
+    Includes scan candidates (high-conviction / bullish / bearish) and symbols
+    the scan attempted but errored on, plus every deep-analysis symbol. A symbol
+    the scan reported on is *grounded*: naming it is not a hallucination.
+    """
+    symbols: set[str] = set()
+    for key in ("high_conviction_setups", "top_bullish", "top_bearish", "errors"):
+        for entry in scan_results.get(key, []) or []:
+            if isinstance(entry, dict) and entry.get("symbol"):
+                symbols.add(_normalize_symbol(str(entry["symbol"])))
+    for analysis in deep_analyses or []:
+        if isinstance(analysis, dict) and analysis.get("symbol"):
+            symbols.add(_normalize_symbol(str(analysis["symbol"])))
+    symbols.discard("")
+    return symbols
+
+
+def find_ungrounded_tickers(
+    briefing: str, scan_results: dict, deep_analyses: list[dict]
+) -> list[str]:
+    """Return ticker-like tokens in the briefing that are absent from the input.
+
+    Best-effort, high-precision heuristic backing the briefing anti-hallucination
+    guardrail: it extracts cashtags and uppercase ticker-shaped tokens, drops
+    known indicator/acronym/common words, and flags anything left that does not
+    appear in the scan or deep-analysis symbols. Bare single-letter tokens are
+    ignored (too noisy, e.g. "Plan B") unless written as an explicit cashtag.
+
+    The result is a sorted, de-duplicated list of the offending tokens, suitable
+    for logging. It is intentionally conservative: it favors missing a borderline
+    case over emitting a false alarm.
+    """
+    allowed = _collect_input_symbols(scan_results, deep_analyses)
+    ungrounded: set[str] = set()
+    for match in _TICKER_PATTERN.finditer(briefing or ""):
+        cashtag, core, suffix = match.group(1), match.group(2), match.group(3)
+        token = core + (suffix or "")
+        # Bare single letters ("A", "B", "F") are too noisy to treat as tickers.
+        if not cashtag and len(token) == 1:
+            continue
+        # Skip known non-ticker acronyms/words unless explicitly cashtagged.
+        if not cashtag and core in _NON_TICKER_TOKENS:
+            continue
+        normalized = _normalize_symbol(token)
+        if normalized and normalized not in allowed:
+            ungrounded.add(token)
+    return sorted(ungrounded)
+
 
 def generate_briefing(
     scan_results: dict,
@@ -80,12 +306,26 @@ def generate_briefing(
     user_content = _build_user_message(scan_results, deep_analyses)
 
     if provider == "anthropic":
-        return _generate_anthropic(user_content, model, api_key)
+        briefing = _generate_anthropic(user_content, model, api_key)
     elif provider == "gemini":
-        return _generate_gemini(user_content, model, api_key)
+        briefing = _generate_gemini(user_content, model, api_key)
     else:
         msg = f"Unknown AI provider: {provider!r}. Use 'gemini' or 'anthropic'."
         raise ValueError(msg)
+
+    # Anti-hallucination guardrail: every ticker named in the briefing should
+    # exist in the scan/analysis data we passed to the model. Log (don't block)
+    # any that don't so grounding regressions are visible in the run logs.
+    ungrounded = find_ungrounded_tickers(briefing, scan_results, deep_analyses)
+    if ungrounded:
+        logger.warning(
+            "Briefing references %d ticker(s) absent from scan/analysis data "
+            "(possible hallucination): %s",
+            len(ungrounded),
+            ", ".join(ungrounded),
+        )
+
+    return briefing
 
 
 def _build_user_message(scan_results: dict, deep_analyses: list[dict]) -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,6 +11,7 @@ import pytest
 from volume_price_analysis.agent.ai_client import (
     _TRUNCATION_WARNING,
     SYSTEM_PROMPT,
+    find_ungrounded_tickers,
     generate_briefing,
 )
 from volume_price_analysis.agent.config import AgentConfig
@@ -2075,3 +2076,154 @@ class TestSystemPromptVolatilityLabeling:
         """The prompt must tell the model the metric is not options-implied vol."""
         lowered = SYSTEM_PROMPT.lower()
         assert "implied volatility" in lowered
+
+
+class TestSystemPromptGrounding:
+    """HOM-45: SYSTEM_PROMPT must instruct the model to only use provided data."""
+
+    def test_prompt_has_grounding_clause(self):
+        lowered = SYSTEM_PROMPT.lower()
+        assert "use only" in lowered
+        assert "never invent" in lowered
+
+    def test_prompt_mentions_tickers_must_come_from_data(self):
+        lowered = SYSTEM_PROMPT.lower()
+        assert "ticker" in lowered
+
+
+class TestFindUngroundedTickers:
+    """HOM-45: flag ticker-like tokens that are absent from the scan/analysis input."""
+
+    @staticmethod
+    def _scan(*, bullish=(), bearish=(), high_conviction=(), errors=()):
+        return {
+            "summary": {},
+            "high_conviction_setups": [{"symbol": s} for s in high_conviction],
+            "top_bullish": [{"symbol": s} for s in bullish],
+            "top_bearish": [{"symbol": s} for s in bearish],
+            "errors": [{"symbol": s, "error": "boom"} for s in errors],
+        }
+
+    def test_grounded_briefing_returns_empty(self):
+        scan = self._scan(bullish=["AAPL"], bearish=["TSLA"])
+        briefing = "## Top Picks\n- AAPL looks bullish\n- TSLA looks bearish"
+        assert find_ungrounded_tickers(briefing, scan, []) == []
+
+    def test_detects_hallucinated_ticker(self):
+        scan = self._scan(bullish=["AAPL"])
+        briefing = "AAPL is great. Also consider ZZZZ for a play."
+        assert find_ungrounded_tickers(briefing, scan, []) == ["ZZZZ"]
+
+    def test_ignores_indicator_acronyms(self):
+        scan = self._scan(bullish=["AAPL"])
+        briefing = (
+            "AAPL: ADX 31, RSI 62, VWAP above, POC/VAH/VAL aligned, "
+            "HV percentile high, OBV rising, MFI 70, CMF positive, ATR wide, BB squeeze, "
+            "14-day DTE, ROC up."
+        )
+        assert find_ungrounded_tickers(briefing, scan, []) == []
+
+    def test_ignores_emphasis_and_common_words(self):
+        scan = self._scan(bullish=["AAPL"])
+        briefing = (
+            "STRONG BULLISH on AAPL. NO TREND elsewhere. VOLUME BREAKOUT, "
+            "EXTREME OVERBOUGHT. WARNING: IMPORTANT risk. US markets, ETF flows, AI theme."
+        )
+        assert find_ungrounded_tickers(briefing, scan, []) == []
+
+    def test_recognizes_symbols_from_deep_analyses(self):
+        scan = self._scan()
+        deep = [{"symbol": "NVDA"}]
+        briefing = "NVDA shows accumulation into the close."
+        assert find_ungrounded_tickers(briefing, scan, deep) == []
+
+    def test_recognizes_symbols_from_error_list(self):
+        scan = self._scan(errors=["GOOGL"])
+        briefing = "Note: GOOGL failed to fetch but was in scope."
+        assert find_ungrounded_tickers(briefing, scan, []) == []
+
+    def test_cashtag_grounded(self):
+        scan = self._scan(bullish=["AAPL"])
+        assert find_ungrounded_tickers("Buy $AAPL calls.", scan, []) == []
+
+    def test_cashtag_hallucinated_is_flagged(self):
+        scan = self._scan(bullish=["AAPL"])
+        assert find_ungrounded_tickers("Rotate into $ZM here.", scan, []) == ["ZM"]
+
+    def test_ignores_bare_single_letters(self):
+        scan = self._scan(bullish=["AAPL"])
+        briefing = "Plan B is fine; option A too; F was not analyzed."
+        assert find_ungrounded_tickers(briefing, scan, []) == []
+
+    def test_handles_class_share_symbol(self):
+        scan = self._scan(bullish=["BRK-B"])
+        briefing = "BRK.B is consolidating near its POC."
+        assert find_ungrounded_tickers(briefing, scan, []) == []
+
+    def test_dedupes_and_sorts(self):
+        scan = self._scan(bullish=["AAPL"])
+        briefing = "WXYZ and MNOP and WXYZ again, plus AAPL."
+        assert find_ungrounded_tickers(briefing, scan, []) == ["MNOP", "WXYZ"]
+
+    def test_handles_empty_briefing(self):
+        scan = self._scan(bullish=["AAPL"])
+        assert find_ungrounded_tickers("", scan, []) == []
+
+    def test_handles_empty_scan_data(self):
+        assert find_ungrounded_tickers("Consider ZZZZ today.", {}, []) == ["ZZZZ"]
+
+
+class TestGenerateBriefingGrounding:
+    """HOM-45: generate_briefing logs a warning when the briefing names unknown tickers."""
+
+    @staticmethod
+    def _scan():
+        return {
+            "summary": {"total_candidates": 1},
+            "high_conviction_setups": [],
+            "top_bullish": [{"symbol": "AAPL"}],
+            "top_bearish": [],
+            "errors": [],
+        }
+
+    def test_logs_warning_on_hallucinated_ticker(self, mocker, caplog):
+        import logging
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "AAPL is bullish. Also buy ZZZZ calls."
+        mock_response.candidates = []
+        mock_client.models.generate_content.return_value = mock_response
+        mocker.patch("google.genai.Client", return_value=mock_client)
+
+        with caplog.at_level(logging.WARNING, logger="volume_price_analysis.agent.ai_client"):
+            result = generate_briefing(
+                scan_results=self._scan(),
+                deep_analyses=[],
+                provider="gemini",
+                api_key="test-key",
+            )
+
+        assert "ZZZZ" in result
+        assert "ZZZZ" in caplog.text
+        assert "hallucination" in caplog.text.lower()
+
+    def test_no_warning_when_grounded(self, mocker, caplog):
+        import logging
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "AAPL is bullish today; watch the VWAP."
+        mock_response.candidates = []
+        mock_client.models.generate_content.return_value = mock_response
+        mocker.patch("google.genai.Client", return_value=mock_client)
+
+        with caplog.at_level(logging.WARNING, logger="volume_price_analysis.agent.ai_client"):
+            generate_briefing(
+                scan_results=self._scan(),
+                deep_analyses=[],
+                provider="gemini",
+                api_key="test-key",
+            )
+
+        assert "hallucination" not in caplog.text.lower()


### PR DESCRIPTION
## Summary

Implements **HOM-45 — [Quick win] O1: Briefing anti-hallucination guardrail**, serving the *grounded AI output* charter pillar.

Two complementary defenses against the briefing LLM naming tickers/levels that don't exist in the scan data:

1. **Prompt-side (prevention):** `SYSTEM_PROMPT` gains an explicit `GROUNDING (CRITICAL)` clause — the model must use **only** tickers, prices, composite scores, and levels present in the provided data, and must never invent, guess, or substitute a symbol.
2. **Output-side (detection):** `generate_briefing()` runs a cheap post-generation check, `find_ungrounded_tickers()`, that extracts ticker-shaped tokens from the generated briefing and **logs a WARNING** for any not present in the scan/deep-analysis input. It logs only — it never blocks or alters delivery.

## Design notes

- **High precision by design** (so warnings stay meaningful, not noise):
  - denylist of indicator/options acronyms (ADX, RSI, VWAP, POC, VAH, VAL, HV, DTE…) and common all-caps words (STRONG, BULLISH, VOLUME, BREAKOUT, WARNING…);
  - bare single-letter tokens ignored (e.g. "Plan B", "grade A") unless written as a `$`-cashtag;
  - class-share normalization so `BRK.B` ↔ `BRK-B` match.
- **Grounded set** = every symbol anywhere in the input: `high_conviction_setups`, `top_bullish`, `top_bearish`, **`errors[].symbol`** (a symbol the scan tried and failed isn't a hallucination), and every `deep_analyses[].symbol`.
- **MCP contract**: no tool signatures touched; change is purely additive. The public helper `find_ungrounded_tickers()` is new and independently testable.

## Verification

- **17 new tests** (`TestSystemPromptGrounding`, `TestFindUngroundedTickers`, `TestGenerateBriefingGrounding`) covering grounded/hallucinated cases, acronym & emphasis-word suppression, deep-analysis & error-list symbols, cashtags, class shares, single letters, dedup/sort, and the `generate_briefing` warning path.
- Full suite: **505 passed, 2 skipped**. `ruff check` + `ruff format` + `mypy` clean. Coverage **96.7%** (gate 80%; `ai_client.py` 100%).
- **Spot-check** on a realistic briefing echoing the actual all-caps insight labels from `analysis.py`: **zero false positives**, one true positive (an invented `PLTR` flagged).

Closes HOM-45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)