### PR TITLE
fix: harden indicators against edge cases (HOM-44)

### DIFF
--- a/src/volume_price_analysis/indicators.py
+++ b/src/volume_price_analysis/indicators.py
@@ -96,6 +96,11 @@ def calculate_volume_profile(data: pd.DataFrame, num_bins: int = 20) -> dict[str
     Returns:
         Dictionary with 'price_levels' and 'volumes' lists
     """
+    # Empty input: min()/max() return NaN and np.linspace would yield all-NaN
+    # price levels (silent garbage). Degrade to neutral zero-filled bins.
+    if data.empty:
+        return {"price_levels": [0.0] * num_bins, "volumes": [0.0] * num_bins}
+
     min_price = data["Low"].min()
     max_price = data["High"].max()
 
@@ -156,7 +161,12 @@ def calculate_vpt(data: pd.DataFrame) -> pd.Series:
     for i in range(1, len(data)):
         prev_close = data["Close"].iloc[i - 1]
         curr_close = data["Close"].iloc[i]
-        price_change_pct = (curr_close - prev_close) / prev_close
+        # A zero prior close makes the percentage change undefined (div-by-zero
+        # -> inf/NaN). Treat it as no measurable change so VPT stays finite.
+        if prev_close == 0:
+            price_change_pct = 0.0
+        else:
+            price_change_pct = (curr_close - prev_close) / prev_close
         vpt.append(vpt[-1] + data["Volume"].iloc[i] * price_change_pct)
 
     return pd.Series(vpt, index=data.index)
@@ -208,6 +218,15 @@ def calculate_mfi(data: pd.DataFrame, period: int = 14) -> pd.Series:
     mfr = positive_mf / negative_mf
     mfi = 100 - (100 / (1 + mfr))
 
+    # Flat window: no positive AND no negative money flow gives 0/0 -> NaN.
+    # (One-sided flow already resolves correctly: negative_mf == 0 with positive
+    # flow yields mfr == inf -> MFI == 100.) Degrade the undefined 0/0 case to a
+    # neutral 50 rather than emitting NaN. The rolling-window warmup stays NaN
+    # because its sums are NaN (NaN == 0 is False), so this only touches fully
+    # flat windows past warmup.
+    flat_window = (positive_mf == 0) & (negative_mf == 0)
+    mfi = mfi.mask(flat_window, 50.0)
+
     return mfi
 
 
@@ -222,7 +241,26 @@ def analyze_volume_trends(data: pd.DataFrame, window: int = 20) -> dict[str, Any
     Returns:
         Dictionary with volume trend analysis
     """
-    avg_volume = data["Volume"].rolling(window=window).mean()
+    # Empty input has no last bar to analyse; return neutral, non-throwing
+    # defaults rather than raising IndexError on the .iloc[-1] lookups below.
+    if data.empty:
+        return {
+            "current_volume": 0,
+            "average_volume": 0,
+            "volume_vs_average": "N/A",
+            "volume_trend": "unknown",
+            "price_direction": "unknown",
+            "divergence_detected": False,
+            "divergence_type": "None",
+        }
+
+    # When history is shorter than the window, a plain rolling mean is all-NaN
+    # (int(NaN) raises) and iloc[-window] raises IndexError. Clamp the lookback
+    # and average over whatever history exists (min_periods=1) so the analysis
+    # still degrades to a real answer. For full history this is identical to the
+    # original rolling mean at the final bar.
+    lookback = min(window, len(data))
+    avg_volume = data["Volume"].rolling(window=window, min_periods=1).mean()
     current_volume = data["Volume"].iloc[-1]
     current_avg = avg_volume.iloc[-1]
 
@@ -230,8 +268,16 @@ def analyze_volume_trends(data: pd.DataFrame, window: int = 20) -> dict[str, Any
     volume_increasing = data["Volume"].iloc[-5:].is_monotonic_increasing
 
     # Calculate price-volume divergence
-    price_direction = "up" if data["Close"].iloc[-1] > data["Close"].iloc[-window] else "down"
-    volume_direction = "up" if current_volume > current_avg else "down"
+    price_direction = "up" if data["Close"].iloc[-1] > data["Close"].iloc[-lookback] else "down"
+
+    # A zero/NaN current volume or average (all-zero or NaN volume window) makes
+    # the ratio undefined; fall back to a neutral comparison and "N/A" display.
+    if pd.isna(current_volume) or pd.isna(current_avg) or current_avg == 0:
+        volume_direction = "down"
+        volume_vs_average = "N/A"
+    else:
+        volume_direction = "up" if current_volume > current_avg else "down"
+        volume_vs_average = f"{((current_volume / current_avg - 1) * 100):.2f}%"
 
     divergence = (price_direction == "up" and volume_direction == "down") or (
         price_direction == "down" and volume_direction == "up"
@@ -242,9 +288,9 @@ def analyze_volume_trends(data: pd.DataFrame, window: int = 20) -> dict[str, Any
     )
 
     return {
-        "current_volume": int(current_volume),
-        "average_volume": int(current_avg),
-        "volume_vs_average": f"{((current_volume / current_avg - 1) * 100):.2f}%",
+        "current_volume": 0 if pd.isna(current_volume) else int(current_volume),
+        "average_volume": 0 if pd.isna(current_avg) else int(current_avg),
+        "volume_vs_average": volume_vs_average,
         "volume_trend": "increasing" if volume_increasing else "decreasing",
         "price_direction": price_direction,
         "divergence_detected": divergence,
@@ -647,6 +693,13 @@ def calculate_enhanced_volume_profile(
         position = "within_value_area"
         interpretation = "Price within value area - balanced market"
 
+    def _distance_pct(level: float) -> float:
+        # A zero reference level (e.g. degenerate all-zero prices give POC/VAH/VAL
+        # of 0) makes the percentage undefined; report 0.0 instead of inf/NaN.
+        if level == 0:
+            return 0.0
+        return float(((current_price / level) - 1) * 100)
+
     return {
         "price_levels": basic_profile["price_levels"],
         "volumes": basic_profile["volumes"],
@@ -657,9 +710,9 @@ def calculate_enhanced_volume_profile(
         "current_price": float(current_price),
         "position": position,
         "interpretation": interpretation,
-        "poc_distance_pct": float(((current_price / poc) - 1) * 100),
-        "vah_distance_pct": float(((current_price / vah) - 1) * 100),
-        "val_distance_pct": float(((current_price / val) - 1) * 100),
+        "poc_distance_pct": _distance_pct(poc),
+        "vah_distance_pct": _distance_pct(vah),
+        "val_distance_pct": _distance_pct(val),
     }
 
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -3233,3 +3233,138 @@ class TestDetectVolumeBreakoutSingleRow:
         assert result["direction"] == "none"
         assert result["current_volume"] == 1000
         assert result["signal"] == "No breakout"
+
+
+class TestIndicatorEdgeCaseHardening:
+    """HOM-44: indicators degrade gracefully instead of throwing/garbage.
+
+    Each test covers a previously-unguarded edge case: insufficient history,
+    empty frames, division by zero, and flat windows that produced NaN.
+    """
+
+    # --- analyze_volume_trends: len < window (IndexError + int(NaN)) ---
+
+    def test_volume_trends_window_larger_than_history(self):
+        """window > len previously raised IndexError on iloc[-window] / int(NaN)."""
+        data = pd.DataFrame(
+            {
+                "Open": [100.0, 101.0, 102.0, 103.0, 104.0],
+                "High": [101.0, 102.0, 103.0, 104.0, 105.0],
+                "Low": [99.0, 100.0, 101.0, 102.0, 103.0],
+                "Close": [100.0, 101.0, 102.0, 103.0, 104.0],
+                "Volume": [1_000_000, 1_100_000, 1_200_000, 1_300_000, 1_400_000],
+            }
+        )
+
+        result = analyze_volume_trends(data, window=20)
+
+        # Degrades to a real analysis over available history, not an exception.
+        assert isinstance(result["current_volume"], int)
+        assert isinstance(result["average_volume"], int)
+        assert result["price_direction"] == "up"  # close rose 100 -> 104
+        assert result["divergence_detected"] in (True, False)
+        assert "nan" not in result["volume_vs_average"].lower()
+        assert "inf" not in result["volume_vs_average"].lower()
+
+    def test_volume_trends_empty_frame(self):
+        """Empty frame returns neutral defaults instead of IndexError."""
+        empty_df = pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
+
+        result = analyze_volume_trends(empty_df, window=20)
+
+        assert result["current_volume"] == 0
+        assert result["average_volume"] == 0
+        assert result["divergence_detected"] is False
+
+    def test_volume_trends_nan_volume_does_not_raise(self):
+        """A trailing NaN volume must not blow up int() conversion."""
+        data = pd.DataFrame(
+            {
+                "Open": [100.0] * 6,
+                "High": [101.0] * 6,
+                "Low": [99.0] * 6,
+                "Close": [100.0, 101.0, 102.0, 103.0, 104.0, 105.0],
+                "Volume": [1_000_000, 1_100_000, 1_200_000, 1_300_000, 1_400_000, np.nan],
+            }
+        )
+
+        result = analyze_volume_trends(data, window=3)
+
+        assert isinstance(result["current_volume"], int)
+        assert isinstance(result["average_volume"], int)
+
+    # --- calculate_volume_profile: empty frame ---
+
+    def test_volume_profile_empty_frame(self):
+        """Empty frame yields zero-filled levels/volumes, never NaN."""
+        empty_df = pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
+
+        profile = calculate_volume_profile(empty_df, num_bins=20)
+
+        assert len(profile["price_levels"]) == 20
+        assert len(profile["volumes"]) == 20
+        assert all(level == 0.0 for level in profile["price_levels"])
+        assert all(vol == 0.0 for vol in profile["volumes"])
+        assert not any(np.isnan(profile["price_levels"]))
+
+    # --- calculate_vpt: prev_close == 0 division by zero ---
+
+    def test_vpt_handles_zero_prev_close(self):
+        """A zero close must not produce inf/NaN VPT on the next bar."""
+        data = pd.DataFrame(
+            {
+                "Close": [100.0, 0.0, 50.0, 60.0],
+                "Volume": [1_000_000, 1_000_000, 1_000_000, 1_000_000],
+            }
+        )
+
+        vpt = calculate_vpt(data)
+
+        assert len(vpt) == 4
+        assert not np.isinf(vpt).any()
+        assert not vpt.isna().any()
+
+    # --- calculate_mfi: flat window NaN -> neutral 50 ---
+
+    def test_mfi_flat_window_is_neutral_not_nan(self):
+        """A perfectly flat window (0/0 money-flow ratio) returns 50, not NaN."""
+        dates = pd.date_range("2024-01-01", periods=30, freq="D")
+        data = pd.DataFrame(
+            {
+                "High": [102.0] * 30,
+                "Low": [98.0] * 30,
+                "Close": [100.0] * 30,  # typical price constant => no money flow
+                "Volume": [1_000_000] * 30,
+            },
+            index=dates,
+        )
+
+        mfi = calculate_mfi(data, period=14)
+
+        # Post-warmup values are defined and neutral, not NaN.
+        assert mfi.iloc[-1] == 50.0
+        assert not mfi.iloc[14:].isna().any()
+
+    # --- calculate_enhanced_volume_profile: POC/VAH/VAL == 0 division ---
+
+    def test_enhanced_profile_zero_poc_no_inf(self):
+        """All-zero prices drive POC/VAH/VAL to 0; distances must not be inf/NaN."""
+        dates = pd.date_range("2024-01-01", periods=30, freq="D")
+        data = pd.DataFrame(
+            {
+                "Open": [0.0] * 30,
+                "High": [0.0] * 30,
+                "Low": [0.0] * 30,
+                "Close": [0.0] * 30,
+                "Volume": [1_000_000] * 30,
+            },
+            index=dates,
+        )
+
+        result = calculate_enhanced_volume_profile(data, num_bins=10)
+
+        assert result["poc"] == 0.0
+        for key in ("poc_distance_pct", "vah_distance_pct", "val_distance_pct"):
+            assert result[key] == 0.0
+            assert not np.isinf(result[key])
+            assert not np.isnan(result[key])


### PR DESCRIPTION
## Summary

A6 quick-win edge-case hardening (HOM-44). Adds guards so indicators **degrade gracefully** to neutral, finite/non-NaN values instead of throwing or emitting silent garbage. **Additive only** — no MCP tool signatures, no scoring/threshold changes.

| Function | Before | After |
|----------|--------|-------|
| `calculate_volume_profile` | empty frame → all-NaN `price_levels` (`min()/max()` over empty → `np.linspace(NaN,NaN)`) | zero-filled bins |
| `analyze_volume_trends` | `window > len(data)` → `IndexError` on `iloc[-window]` + `ValueError` from `int(NaN)`; empty → `IndexError` | clamped lookback, averages available history (`min_periods=1`), neutral defaults on empty; zero/NaN volume guarded |
| `calculate_vpt` | `prev_close == 0` → div-by-zero `inf`/`NaN` (numpy scalar, no raise) | `0%` change, VPT stays finite |
| `calculate_mfi` | fully flat window → `0/0` → `NaN` | neutral `50`; one-sided flows (→100 / →0) and warmup `NaN` preserved |
| `calculate_enhanced_volume_profile` | `POC/VAH/VAL == 0` → `inf`/`NaN` distance% | `0.0` distance |

## Why normal output is unchanged
- `min_periods=1` equals the default rolling mean at the final full window.
- `lookback == window` whenever `len(data) >= window`.
- All new guards trigger **only** on degenerate inputs (empty / zero-denominator / fully-flat).
- The empty-frame paths previously **raised**, so no working consumer relied on them.

## No lookahead bias
Value at bar *t* still uses only bars ≤ *t* (`min_periods=1` rolling mean; `iloc[-lookback]` reads a past close).

## Testing
- New `TestIndicatorEdgeCaseHardening` (7 tests), written test-first (RED → GREEN).
- Full suite: **495 passed, 2 skipped**, coverage **96%** (indicators.py **99%**, gate 80%).
- `ruff format`, `ruff check`, `mypy src/` all clean.
- Ran `indicator-validator` review — no critical/medium findings; confirmed no lookahead, unchanged normal path, preserved return shapes.

## Scope note
Sibling PR for HOM-41 guards the *enhanced* profile's empty-frame early-return; this PR guards the *basic* `calculate_volume_profile` empty case plus the `POC/VAH/VAL` zero-division in the enhanced profile. They touch different functions/lines and merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)