### PR TITLE
feat: rolling/anchored VWAP option for price_vs_vwap (HOM-84)

### DIFF
--- a/src/volume_price_analysis/backtest.py
+++ b/src/volume_price_analysis/backtest.py
@@ -89,7 +89,10 @@ def forward_returns(data: pd.DataFrame, horizon: int) -> pd.Series:
 
 
 def causal_score_at(
-    data: pd.DataFrame, bar_index: int, holding_period: int = 14
+    data: pd.DataFrame,
+    bar_index: int,
+    holding_period: int = 14,
+    vwap_window: int | None = None,
 ) -> dict[str, float]:
     """Compute the composite-score snapshot *as of* bar ``bar_index``.
 
@@ -101,6 +104,9 @@ def causal_score_at(
         data: Full OHLCV DataFrame.
         bar_index: Positional index of the bar to evaluate.
         holding_period: Holding period passed through to the scorer.
+        vwap_window: VWAP anchoring for ``price_vs_vwap`` (``None`` = cumulative,
+            int = rolling trailing-window). Threaded into the scorer so the
+            harness can A/B anchoring variants under the same causal guarantee.
 
     Returns:
         Dict with ``composite_score``, ``adx`` and ``iv_percentile`` at ``t``.
@@ -112,7 +118,7 @@ def causal_score_at(
         raise IndexError(f"bar_index {bar_index} out of range for data of length {len(data)}")
 
     window = data.iloc[: bar_index + 1]
-    composite = calculate_composite_score(window, holding_period)
+    composite = calculate_composite_score(window, holding_period, vwap_window=vwap_window)
 
     # ADX and IV come from the same fixed parameters the production scan gates
     # on (period-14 ADX, 20-bar IV), so the high-conviction gate is faithful.
@@ -136,6 +142,7 @@ def compute_observations(
     min_history: int = 50,
     step: int = 1,
     symbol: str | None = None,
+    vwap_window: int | None = None,
 ) -> pd.DataFrame:
     """Build the (signal, forward-return) observation set for one symbol.
 
@@ -151,6 +158,8 @@ def compute_observations(
             (lets indicators warm up).
         step: Evaluate every ``step``-th bar to reduce overlap between windows.
         symbol: Optional label stored in a ``symbol`` column.
+        vwap_window: VWAP anchoring threaded into the scorer (``None`` =
+            cumulative, int = rolling trailing-window).
 
     Returns:
         DataFrame with columns ``bar``, ``date``, ``composite_score``, ``adx``,
@@ -172,7 +181,7 @@ def compute_observations(
     rows: list[dict[str, Any]] = []
     for t in range(first, last + 1, step):
         fwd_t = float(fwd[t])
-        snap = causal_score_at(data, t, holding_period)
+        snap = causal_score_at(data, t, holding_period, vwap_window=vwap_window)
         # Drop dirty bars: a data gap (NaN Close) can produce a NaN forward
         # return or a NaN score; never let one leak into the evidence set.
         if np.isnan(fwd_t) or np.isnan(snap["composite_score"]):
@@ -334,9 +343,12 @@ def run_symbol_backtest(
     min_history: int = 50,
     step: int = 1,
     symbol: str | None = None,
+    vwap_window: int | None = None,
 ) -> dict[str, Any]:
     """Compute observations and evaluate them for a single symbol's data."""
-    obs = compute_observations(data, horizon, holding_period, min_history, step, symbol=symbol)
+    obs = compute_observations(
+        data, horizon, holding_period, min_history, step, symbol=symbol, vwap_window=vwap_window
+    )
     return {"observations": obs, "evaluation": evaluate_observations(obs)}
 
 
@@ -365,6 +377,7 @@ def format_report(evaluation: dict[str, Any], meta: dict[str, Any]) -> str:
         f"Holding: {meta.get('holding_period', '?')}d   "
         f"Step: {meta.get('step', 1)}"
     )
+    lines.append(f"VWAP anchor: {meta.get('vwap_anchor', 'cumulative')}")
     lines.append(
         f"Observations: {evaluation['n']}  (directional: {evaluation.get('n_directional', '?')})"
     )
@@ -414,18 +427,29 @@ def run_evidence(
     holding_period: int = 14,
     min_history: int = 50,
     step: int = 1,
+    vwap_window: int | None = None,
 ) -> dict[str, Any]:
     """Fetch data for symbols, compute pooled observations, and evaluate.
 
     Per-symbol fetch failures are isolated and skipped so one bad symbol does
-    not sink the run.
+    not sink the run. ``vwap_window`` selects the VWAP anchoring fed to the
+    scorer (``None`` = cumulative, int = rolling trailing-window) so cumulative
+    and rolling anchors can be compared on the same pooled universe.
     """
     frames: list[pd.DataFrame] = []
     errors: list[str] = []
     for sym in symbols:
         try:
             data = fetch_stock_data(sym, None, None, period)
-            obs = compute_observations(data, horizon, holding_period, min_history, step, symbol=sym)
+            obs = compute_observations(
+                data,
+                horizon,
+                holding_period,
+                min_history,
+                step,
+                symbol=sym,
+                vwap_window=vwap_window,
+            )
             if obs.empty:
                 errors.append(f"{sym}: insufficient history")
             else:
@@ -438,6 +462,22 @@ def run_evidence(
     return {"observations": pooled, "evaluation": evaluation, "errors": errors}
 
 
+def _parse_vwap_window(value: str) -> int | None:
+    """Parse the ``--vwap-window`` flag: ``cumulative``/``none`` -> None, else int."""
+    normalized = value.strip().lower()
+    if normalized in ("cumulative", "none", ""):
+        return None
+    try:
+        window = int(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--vwap-window must be 'cumulative' or a positive integer, got {value!r}"
+        ) from exc
+    if window < 1:
+        raise argparse.ArgumentTypeError(f"--vwap-window must be >= 1, got {window}")
+    return window
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """CLI entry point: ``vpa-backtest AAPL MSFT --horizon 14 --period 2y``."""
     parser = argparse.ArgumentParser(description="VPA strictly-causal evidence harness")
@@ -447,6 +487,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--holding-period", type=int, default=14, help="Scorer holding period")
     parser.add_argument("--min-history", type=int, default=50, help="Warm-up bars before first")
     parser.add_argument("--step", type=int, default=1, help="Evaluate every Nth bar")
+    parser.add_argument(
+        "--vwap-window",
+        type=_parse_vwap_window,
+        default=None,
+        help="VWAP anchor for price_vs_vwap: 'cumulative' (default) or a rolling window size",
+    )
     args = parser.parse_args(argv)
 
     result = run_evidence(
@@ -456,7 +502,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         holding_period=args.holding_period,
         min_history=args.min_history,
         step=args.step,
+        vwap_window=args.vwap_window,
     )
+    anchor = "cumulative" if args.vwap_window is None else f"rolling-{args.vwap_window}"
     print(
         format_report(
             result["evaluation"],
@@ -465,6 +513,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "horizon": args.horizon,
                 "holding_period": args.holding_period,
                 "step": args.step,
+                "vwap_anchor": anchor,
             },
         )
     )

--- a/src/volume_price_analysis/indicators.py
+++ b/src/volume_price_analysis/indicators.py
@@ -62,24 +62,52 @@ def calculate_obv(data: pd.DataFrame) -> pd.Series:
     return pd.Series(obv, index=data.index)
 
 
-def calculate_vwap(data: pd.DataFrame) -> pd.Series:
+def calculate_vwap(data: pd.DataFrame, window: int | None = None) -> pd.Series:
     """
     Calculate Volume Weighted Average Price (VWAP).
 
     VWAP is the average price weighted by volume. It's used to identify
     the true average price and is often used as a trading benchmark.
 
+    Two anchoring modes are supported:
+
+    - ``window=None`` (default): **cumulative** anchor — the volume-weighted
+      mean of every bar from the start of the series. Over long lookbacks this
+      anchor barely moves day-to-day and grows stale as a "fair value" read.
+    - ``window=N``: **rolling** anchor — the volume-weighted mean of the trailing
+      ``N`` bars only, so the benchmark tracks recent price/volume action. Uses
+      ``min_periods=1`` so the first bars degrade gracefully to a shorter anchor
+      instead of emitting ``NaN`` (a window larger than the series is therefore
+      identical to the cumulative anchor). Both modes are strictly causal: bar
+      ``t`` only ever sees bars ``<= t``.
+
     Args:
         data: DataFrame with 'High', 'Low', 'Close', and 'Volume' columns
+        window: Trailing-bar window for the rolling anchor. ``None`` keeps the
+            cumulative anchor. Must be >= 1 when provided.
 
     Returns:
         Series containing VWAP values
+
+    Raises:
+        ValueError: If ``window`` is provided and is < 1.
     """
     typical_price = (data["High"] + data["Low"] + data["Close"]) / 3
-    cum_vol = data["Volume"].cumsum()
-    vwap = (typical_price * data["Volume"]).cumsum() / cum_vol
-    vwap = vwap.where(cum_vol != 0, np.nan)
-    return vwap
+    pv = typical_price * data["Volume"]
+
+    if window is None:
+        cum_vol = data["Volume"].cumsum()
+        vwap = pv.cumsum() / cum_vol
+        return vwap.where(cum_vol != 0, np.nan)
+
+    if window < 1:
+        raise ValueError(f"window must be >= 1, got {window}")
+
+    roll_vol = data["Volume"].rolling(window=window, min_periods=1).sum()
+    vwap = pv.rolling(window=window, min_periods=1).sum() / roll_vol
+    # A window whose volume sums to zero has no defined VWAP; emit NaN rather
+    # than a divide-by-zero inf so it becomes a dropped (not garbage) reading.
+    return vwap.where(roll_vol != 0, np.nan)
 
 
 def calculate_volume_profile(data: pd.DataFrame, num_bins: int = 20) -> dict[str, list]:
@@ -1113,7 +1141,9 @@ def calculate_expected_move(
 # ============================================================================
 
 
-def calculate_composite_score(data: pd.DataFrame, holding_period: int = 14) -> dict[str, Any]:
+def calculate_composite_score(
+    data: pd.DataFrame, holding_period: int = 14, vwap_window: int | None = None
+) -> dict[str, Any]:
     """
     Calculate composite signal score for options trading.
 
@@ -1125,6 +1155,13 @@ def calculate_composite_score(data: pd.DataFrame, holding_period: int = 14) -> d
     Args:
         data: DataFrame with OHLC and Volume data
         holding_period: Days for options holding period (affects indicator tuning)
+        vwap_window: Anchoring for the ``price_vs_vwap`` component. ``None``
+            (default) uses the cumulative VWAP anchor; an integer uses a rolling
+            trailing-``N``-bar anchor (see :func:`calculate_vwap`). The default
+            stays cumulative: the HOM-84 A8 evidence run (26-symbol balanced
+            universe, 2y, 14d horizon) found rolling anchors neutral-to-slightly
+            worse (lower hit-rate, smaller |IC|), so the rolling path ships as an
+            opt-in for future tuning rather than as the default.
 
     Returns:
         Dictionary with composite score and breakdown
@@ -1149,7 +1186,7 @@ def calculate_composite_score(data: pd.DataFrame, holding_period: int = 14) -> d
     # Calculate indicators
     obv = calculate_obv(data)
     ad_line = calculate_accumulation_distribution(data)
-    vwap = calculate_vwap(data)
+    vwap = calculate_vwap(data, vwap_window)
     vwma = calculate_vwma(data, volume_window)
     mfi = calculate_mfi(data, mfi_period)
     cmf = calculate_chaikin_money_flow(data, volume_window)

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -126,6 +126,101 @@ def test_causal_score_out_of_range_raises():
         causal_score_at(data, 40, holding_period=14)
 
 
+def _strong_uptrend(n: int) -> pd.DataFrame:
+    """Monotonic strong uptrend: cumulative and short-rolling VWAP anchors diverge."""
+    dates = pd.date_range(start="2022-01-01", periods=n, freq="B")
+    close = np.linspace(100.0, 400.0, n)
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": close - 1.0,
+            "High": close + 1.0,
+            "Low": close - 1.0,
+            "Close": close,
+            "Volume": np.full(n, 1_000_000.0),
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# VWAP anchoring (HOM-84): the harness threads vwap_window into the scorer
+# --------------------------------------------------------------------------- #
+
+
+def test_causal_score_threads_vwap_window_into_scorer():
+    """causal_score_at forwards its vwap_window straight to the composite scorer."""
+    from unittest.mock import patch
+
+    data = _synthetic_data(80)
+    with patch(
+        "volume_price_analysis.backtest.calculate_composite_score",
+        wraps=backtest.calculate_composite_score,
+    ) as spy:
+        causal_score_at(data, 79, holding_period=14, vwap_window=15)
+
+    assert spy.call_count == 1
+    call = spy.call_args
+    passed = call.kwargs.get("vwap_window", call.args[2] if len(call.args) > 2 else None)
+    assert passed == 15
+
+
+def test_compute_observations_threads_vwap_window_into_scorer():
+    """Every per-bar score in an observation set uses the requested anchor."""
+    from unittest.mock import patch
+
+    data = _synthetic_data(120)
+    with patch(
+        "volume_price_analysis.backtest.calculate_composite_score",
+        wraps=backtest.calculate_composite_score,
+    ) as spy:
+        compute_observations(
+            data, horizon=10, holding_period=14, min_history=60, step=10, vwap_window=20
+        )
+
+    # bars 59..99 step 10 -> 5 evaluable bars, each scored exactly once
+    assert spy.call_count >= 5
+    windows = [
+        c.kwargs.get("vwap_window", c.args[2] if len(c.args) > 2 else None)
+        for c in spy.call_args_list
+    ]
+    assert all(w == 20 for w in windows)
+
+
+def test_rolling_anchor_is_invariant_to_future_bars():
+    """The no-lookahead contract holds for the rolling VWAP anchor too.
+
+    The cumulative arm is locked by test_causal_score_is_invariant_to_future_bars;
+    this proves a non-None vwap_window introduces no future leak either.
+    """
+    data = _synthetic_data(200)
+    t = 120
+
+    minimal = causal_score_at(data.iloc[: t + 1], t, holding_period=14, vwap_window=10)
+    full = causal_score_at(data, t, holding_period=14, vwap_window=10)
+
+    corrupted = data.copy()
+    corrupted.loc[corrupted.index[t + 1 :], ["Close", "High", "Low"]] *= 5.0
+    corrupted.loc[corrupted.index[t + 1 :], "Volume"] *= 100.0
+    after = causal_score_at(corrupted, t, holding_period=14, vwap_window=10)
+
+    assert minimal["composite_score"] == full["composite_score"]
+    assert full["composite_score"] == after["composite_score"]
+
+
+def test_windowed_anchor_changes_some_scores_on_trend():
+    """A short rolling anchor moves at least one composite score vs the cumulative anchor."""
+    data = _strong_uptrend(160)
+    cumulative = compute_observations(
+        data, horizon=10, holding_period=14, min_history=50, step=5, vwap_window=None
+    )
+    rolling = compute_observations(
+        data, horizon=10, holding_period=14, min_history=50, step=5, vwap_window=5
+    )
+    # Same bars are evaluated in both arms; the anchor change must perturb scores.
+    assert len(cumulative) == len(rolling) and len(cumulative) > 0
+    assert (cumulative["composite_score"].to_numpy() != rolling["composite_score"].to_numpy()).any()
+
+
 # --------------------------------------------------------------------------- #
 # compute_observations
 # --------------------------------------------------------------------------- #
@@ -460,3 +555,32 @@ def test_main_prints_report_and_returns_zero(monkeypatch, capsys):
     assert "VPA EVIDENCE HARNESS" in out
     assert "Errors:" in out  # BAD failure surfaced
     assert "BAD" in out
+    assert "VWAP anchor: cumulative" in out  # default anchor labelled
+
+
+def test_main_rolling_vwap_window_labels_anchor(monkeypatch, capsys):
+    """--vwap-window N runs the rolling arm and labels it in the report."""
+    _fake_fetch_factory(monkeypatch)
+    rc = main(["GOOD", "--horizon", "10", "--min-history", "50", "--vwap-window", "20"])
+    assert rc == 0
+    assert "VWAP anchor: rolling-20" in capsys.readouterr().out
+
+
+def test_main_vwap_window_cumulative_keyword(monkeypatch, capsys):
+    """The literal 'cumulative' keyword selects the cumulative anchor."""
+    _fake_fetch_factory(monkeypatch)
+    rc = main(["GOOD", "--horizon", "10", "--min-history", "50", "--vwap-window", "cumulative"])
+    assert rc == 0
+    assert "VWAP anchor: cumulative" in capsys.readouterr().out
+
+
+def test_main_vwap_window_rejects_invalid():
+    """A non-integer, non-keyword --vwap-window is rejected at parse time."""
+    with pytest.raises(SystemExit):
+        main(["GOOD", "--vwap-window", "abc"])
+
+
+def test_main_vwap_window_rejects_nonpositive():
+    """--vwap-window must be a positive window when numeric."""
+    with pytest.raises(SystemExit):
+        main(["GOOD", "--vwap-window", "0"])

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -106,6 +106,124 @@ class TestVWAP:
         assert not vwap.isna().any()
 
 
+class TestRollingVWAP:
+    """Tests for the rolling/windowed VWAP anchoring option."""
+
+    def test_rolling_window_tracks_recent_prices(self, uptrend_data):
+        """A short rolling VWAP sits near recent prices, above the cumulative anchor."""
+        cumulative = calculate_vwap(uptrend_data)
+        rolling = calculate_vwap(uptrend_data, window=3)
+
+        # In a steady uptrend the cumulative anchor lags far below the latest
+        # price; a 3-bar rolling anchor stays close to it.
+        assert rolling.iloc[-1] > cumulative.iloc[-1]
+        last3_low = uptrend_data["Low"].iloc[-3:].min()
+        last3_high = uptrend_data["High"].iloc[-3:].max()
+        assert last3_low <= rolling.iloc[-1] <= last3_high
+
+    def test_rolling_window_tracks_recent_prices_downtrend(self, downtrend_data):
+        """In a downtrend the rolling anchor sits below the lagging cumulative anchor."""
+        cumulative = calculate_vwap(downtrend_data)
+        rolling = calculate_vwap(downtrend_data, window=3)
+
+        assert rolling.iloc[-1] < cumulative.iloc[-1]
+        last3_low = downtrend_data["Low"].iloc[-3:].min()
+        last3_high = downtrend_data["High"].iloc[-3:].max()
+        assert last3_low <= rolling.iloc[-1] <= last3_high
+
+    def test_rolling_window_covering_all_bars_equals_cumulative(self, uptrend_data):
+        """window >= len(data) with min_periods degrades to the cumulative anchor."""
+        cumulative = calculate_vwap(uptrend_data)
+        rolling = calculate_vwap(uptrend_data, window=len(uptrend_data) + 50)
+        pd.testing.assert_series_equal(rolling, cumulative, check_names=False)
+
+    def test_rolling_window_no_nan_on_short_history(self, uptrend_data):
+        """A window longer than the series still yields values (min_periods=1)."""
+        rolling = calculate_vwap(uptrend_data, window=1000)
+        assert not rolling.isna().any()
+        assert len(rolling) == len(uptrend_data)
+
+    def test_rolling_window_within_price_range(self, sample_stock_data):
+        """Rolling VWAP stays within the overall high-low envelope."""
+        rolling = calculate_vwap(sample_stock_data, window=5)
+        assert all(rolling >= sample_stock_data["Low"].min())
+        assert all(rolling <= sample_stock_data["High"].max())
+
+    def test_rolling_window_rejects_nonpositive(self, sample_stock_data):
+        """A window < 1 is a programming error and must raise."""
+        with pytest.raises(ValueError):
+            calculate_vwap(sample_stock_data, window=0)
+
+    def test_rolling_window_zero_volume_is_nan_not_inf(self):
+        """A window with zero total volume yields NaN, never a divide-by-zero inf."""
+        data = pd.DataFrame(
+            {
+                "High": [10.0, 11.0, 12.0],
+                "Low": [9.0, 10.0, 11.0],
+                "Close": [9.5, 10.5, 11.5],
+                "Volume": [0, 0, 0],
+            }
+        )
+        rolling = calculate_vwap(data, window=2)
+        assert rolling.isna().all()
+        assert not np.isinf(rolling).any()
+
+    def test_rolling_window_excludes_nan_volume_bars(self):
+        """A NaN-volume bar is dropped from the window, not carried as garbage/inf.
+
+        Both numerator and denominator skip the NaN bar, so the rolling VWAP is
+        the volume-weighted price of the *valid* trailing bars. Emitting a finite
+        value (rather than NaN) keeps the composite's price_vs_vwap branch from
+        silently collapsing to its bearish ``else`` default on a data gap.
+        """
+        data = pd.DataFrame(
+            {
+                "High": [10.0, 11.0, 12.0],
+                "Low": [9.0, 10.0, 11.0],
+                "Close": [9.5, 10.5, 11.5],
+                "Volume": [100.0, float("nan"), 200.0],
+            }
+        )
+        rolling = calculate_vwap(data, window=2)
+        # bar 1 window [bar0, bar1(no vol)] -> VWAP of bar0 only = typical_price[0]
+        assert rolling.iloc[1] == pytest.approx(9.5)
+        # bar 2 window [bar1(no vol), bar2] -> VWAP of bar2 only = typical_price[2]
+        assert rolling.iloc[2] == pytest.approx(11.5)
+        assert not np.isinf(rolling).any()
+
+    def test_composite_threads_vwap_window_to_anchor(self, sample_stock_data):
+        """calculate_composite_score routes its vwap_window into calculate_vwap."""
+        from unittest.mock import patch
+
+        with patch("volume_price_analysis.indicators.calculate_vwap", wraps=calculate_vwap) as spy:
+            calculate_composite_score(sample_stock_data, vwap_window=10)
+
+        used_windows = []
+        for call in spy.call_args_list:
+            if "window" in call.kwargs:
+                used_windows.append(call.kwargs["window"])
+            elif len(call.args) > 1:
+                used_windows.append(call.args[1])
+        assert 10 in used_windows
+
+    def test_composite_default_vwap_is_cumulative(self, sample_stock_data):
+        """Default (no vwap_window) preserves the cumulative anchor (window=None)."""
+        from unittest.mock import patch
+
+        with patch("volume_price_analysis.indicators.calculate_vwap", wraps=calculate_vwap) as spy:
+            calculate_composite_score(sample_stock_data)
+
+        used_windows = []
+        for call in spy.call_args_list:
+            if "window" in call.kwargs:
+                used_windows.append(call.kwargs["window"])
+            elif len(call.args) > 1:
+                used_windows.append(call.args[1])
+            else:
+                used_windows.append(None)
+        assert all(w is None for w in used_windows)
+
+
 class TestVolumeProfile:
     """Tests for Volume Profile calculation."""
 


### PR DESCRIPTION
## What & why (HOM-84 / A3 of the HOM-49 composite-score-quality track)

`price_vs_vwap` reads off a **cumulative-anchor** VWAP that drifts stale over long lookbacks (over a 2y slice it's essentially the volume-weighted mean of the whole window). This PR adds a configurable **rolling/anchored** VWAP option feeding `price_vs_vwap`, and selects the default **by A8 evidence**.

### Changes (all additive, backward-compatible — no MCP tool signature changes)
- `calculate_vwap(data, window=None)` — `None` = cumulative (unchanged); int = strictly-causal rolling trailing-window anchor (`min_periods=1` graceful degradation; zero-volume window → `NaN`, not `inf`; NaN-volume bars cleanly excluded).
- `calculate_composite_score(data, holding_period=14, vwap_window=None)` — threads the anchor into the `price_vs_vwap` component.
- A8 harness: `causal_score_at`/`compute_observations`/`run_symbol_backtest`/`run_evidence` accept `vwap_window`; new CLI flag `vpa-backtest ... --vwap-window cumulative|N` (labelled in the report). Lets the harness A/B anchors on the same causal slices.

## Evidence gate (A8) — broad/balanced universe, strictly causal

26-symbol balanced universe (mega-cap tech, financials, energy, healthcare, consumer, industrials, telecom defensives, **plus real laggards** DIS/INTC/PYPL/F/PFE — not the 4 bull-only mega-caps), `period=2y`, `horizon=14d`, `step=5`, 2,288 pooled observations. Each arm ≡ `vpa-backtest <universe> --vwap-window <N>`.

```
anchor              n  n_dir   hit_dir   dir_ret  spearmanIC   pearsonIC
cumulative       2288   2040    47.84%    -0.18%     -0.0712     -0.0714
rolling-10       2288   2121    47.71%    -0.31%     -0.0437     -0.0516
rolling-20       2288   2102    47.38%    -0.32%     -0.0600     -0.0651
rolling-30       2288   2101    47.55%    -0.29%     -0.0535     -0.0619
rolling-50       2288   2080    47.64%    -0.26%     -0.0478     -0.0588

HIGH-CONVICTION GATE (|score|>=4 & ADX>=28 & IV<=50)
  cumulative   n=33  hit=54.55%   rolling-10 n=38 50.00%  rolling-20 n=40 52.50%
  rolling-30   n=34  hit=55.88%   rolling-50 n=35 60.00%
```

### Read
- The composite's IC is **negative everywhere** (≈ −0.07) — the score is mildly contrarian to 14d forward returns on this sample. That's a composite-quality issue for the broader HOM-49 track, not specific to VWAP anchoring.
- For the **anchoring A/B** (the only thing this PR changes): cumulative wins or ties — rolling has lower directional hit-rate (47.4–47.7% vs **47.84%**), more-negative directional return (−0.26…−0.32% vs **−0.18%**), and smaller |IC|. The high-conviction gate (n=33–40) is far too small to lean on (rolling-50's 60% is noise).
- With overlapping windows (step 5 / horizon 14) effective N ≪ 2288, so the ~0.01–0.03 IC gaps are within noise. **Honest verdict: rolling is neutral-to-slightly-worse and does not clear the bar to change the default.**

### Decision
**Default stays cumulative** (evidence-selected winner). The rolling path ships as an **opt-in** — useful for future tuning (other horizons, intraday data, or as a standalone signal) and the reusable `--vwap-window` harness flag — without changing any production scoring today.

## Quality gates
- `ruff check`/`format` clean, `mypy src/` clean.
- Tests: **540 passed, 2 skipped, coverage 98%** (≥80% gate). `indicators.py` 100%.
- New tests cover: rolling math, cumulative-equivalence at large windows, `min_periods=1` short-history, zero-volume→NaN, NaN-volume exclusion, downtrend tracking, composite/harness threading, CLI parsing, and **no-lookahead invariance re-locked for the rolling arm**.
- Reviewed with the repo's `indicator-validator` and `scan-reviewer` skills; findings addressed (added the NaN-volume and rolling-arm causality tests they flagged).

Closes HOM-84.