### PR TITLE
fix(agent): linkify only actual scan symbols in briefing emails

### DIFF
--- a/.claude/rules/dev-commands.md
+++ b/.claude/rules/dev-commands.md
@@ -4,7 +4,8 @@
 uv sync --all-extras --dev          # install dependencies
 uv run pytest                       # run all tests
 uv run pytest tests/test_indicators.py                        # single file
-uv run pytest tests/test_indicators.py::test_calculate_obv   # single test
+uv run pytest tests/test_indicators.py::TestOBV::test_obv_basic_calculation  # single test
+uv run pytest -n 0                  # serial run (disable pytest-xdist parallelism, e.g. for pdb)
 uv run pytest --cov=src/volume_price_analysis --cov-report=term-missing  # coverage
 uv run ruff format src/ tests/      # format
 uv run ruff check --fix src/ tests/ # lint + auto-fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "pytest-mock==3.15.1",
     "ruff==0.15.20",
     "mypy==2.1.0",
+    "pytest-xdist==3.8.0",
 ]
 
 [tool.pytest.ini_options]
@@ -42,6 +43,10 @@ python_functions = ["test_*"]
 addopts = [
     "-v",
     "--strict-markers",
+    # Parallelize across CPU cores (pytest-xdist). Coverage still aggregates
+    # correctly across workers via pytest-cov. Override with `-p no:xdist` or
+    # `-n 0` when debugging a single test.
+    "-n=auto",
     "--cov=src/volume_price_analysis",
     "--cov-report=term-missing",
     "--cov-report=html",

--- a/src/volume_price_analysis/agent/ai_client.py
+++ b/src/volume_price_analysis/agent/ai_client.py
@@ -36,7 +36,17 @@ VOLATILITY HONESTY: The volatility percentile in the data (fields named
 realized price moves — it is NOT options-market implied volatility (IV). Always
 label it as an HV percentile (e.g., "HV percentile 78% (proxy)") and never
 present it as implied volatility. Frame cheap/expensive options conclusions as
-inferences from HV, not measured IV.
+inferences from HV, not measured IV. Note the percentile ranks the symbol
+against its OWN recent history: a low HV percentile means volatility is low
+for that symbol, not that the expected move is small in absolute terms.
+
+CONSISTENCY: Cite exactly ONE value per metric per symbol. If a symbol appears
+in both the scan results and the deep analysis, use the deep-analysis values
+for prices, targets, and levels — never quote a second, conflicting number for
+the same metric elsewhere in the briefing. The "upper_target" / "lower_target"
+fields are a ±1 standard deviation expected move over the holding period;
+label them as such (e.g., "14-day ±1σ upper target"), not as predictions or
+price objectives.
 
 Format the briefing in markdown with clear sections:
 1. **Executive Summary** - 2-3 sentence overview of today's market setup
@@ -454,11 +464,46 @@ def _project_deep_analysis(analysis: dict) -> dict:
     return projected
 
 
+# Scan-candidate fields superseded by the deep analysis for the same symbol.
+# The scan and the deep analysis compute expected-move targets from different
+# data windows, so passing both invites the model to cite two conflicting
+# targets for one symbol (e.g. a "$40.32 scan target" next to a "$39.75
+# 14-day lower target").
+_SCAN_FIELDS_SUPERSEDED_BY_DEEP = ("key_levels", "expected_move_pct")
+
+
+def _drop_superseded_scan_fields(projected_scan: dict, deep_analyses: list[dict]) -> dict:
+    """Strip scan-level targets from candidates that also have a deep analysis.
+
+    Returns a copy; candidate dicts are shared with the caller's scan results
+    and must not be mutated.
+    """
+    deep_symbols = {
+        a.get("symbol") for a in deep_analyses or [] if isinstance(a, dict) and a.get("symbol")
+    }
+    if not deep_symbols:
+        return projected_scan
+
+    result = dict(projected_scan)
+    for key in ("high_conviction_setups", "top_bullish", "top_bearish"):
+        candidates = result.get(key)
+        if not isinstance(candidates, list):
+            continue
+        result[key] = [
+            {k: v for k, v in c.items() if k not in _SCAN_FIELDS_SUPERSEDED_BY_DEEP}
+            if isinstance(c, dict) and c.get("symbol") in deep_symbols
+            else c
+            for c in candidates
+        ]
+    return result
+
+
 def _build_user_message(
     scan_results: dict, deep_analyses: list[dict], earnings_preamble: str = ""
 ) -> str:
     """Build the user message with structured data for the AI."""
     projected_scan = _project_scan_results(scan_results)
+    projected_scan = _drop_superseded_scan_fields(projected_scan, deep_analyses)
     user_content = "Generate a morning options trading briefing from this data:\n\n"
     if earnings_preamble:
         user_content += earnings_preamble + "\n"

--- a/src/volume_price_analysis/agent/email_sender.py
+++ b/src/volume_price_analysis/agent/email_sender.py
@@ -5,6 +5,7 @@ import logging
 import re
 import smtplib
 import ssl
+from collections.abc import Collection
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
@@ -22,131 +23,29 @@ def _parse_recipients(to_addr: str) -> list[str]:
     return recipients
 
 
-# Matches standalone 1-5 uppercase-letter words NOT already inside an <a> tag.
-# We use a negative lookahead so we don't double-wrap existing links.
-_TICKER_RE = re.compile(r"(?<![a-zA-Z<>])([A-Z]{1,5})(?![a-z>])")
 _TRADINGVIEW_BASE = "https://www.tradingview.com/chart/?symbol="
 
-# Common English words that look like tickers — skip linking them.
-_SKIP_WORDS: frozenset[str] = frozenset(
-    {
-        "A",
-        "AN",
-        "BE",
-        "BY",
-        "DO",
-        "GO",
-        "HE",
-        "IN",
-        "IS",
-        "IT",
-        "ME",
-        "MY",
-        "NO",
-        "OF",
-        "ON",
-        "OR",
-        "TO",
-        "UP",
-        "US",
-        "WE",
-        "ALL",
-        "AND",
-        "ARE",
-        "BUT",
-        "CAN",
-        "FOR",
-        "HAS",
-        "NOT",
-        "THE",
-        "WAS",
-        "YOU",
-        "ALSO",
-        "BEEN",
-        "FROM",
-        "HAVE",
-        "HIGH",
-        "INTO",
-        "LONG",
-        "MOST",
-        "NOTE",
-        "ONLY",
-        "OVER",
-        "PAST",
-        "PUTS",
-        "RISK",
-        "SELL",
-        "SOME",
-        "THAN",
-        "THAT",
-        "THEM",
-        "THEN",
-        "THEY",
-        "THIS",
-        "TIME",
-        "VERY",
-        "WEAK",
-        "WITH",
-        "YOUR",
-        "CALLS",
-        "COULD",
-        "DAILY",
-        "DELTA",
-        "ENTRY",
-        "FOCUS",
-        "GIVEN",
-        "INDEX",
-        "LARGE",
-        "LEVEL",
-        "LOWER",
-        "MAJOR",
-        "MACRO",
-        "MIXED",
-        "MODEL",
-        "MONEY",
-        "MONTHLY",
-        "MULTI",
-        "PRICE",
-        "RANGE",
-        "RATIO",
-        "SETUP",
-        "SHORT",
-        "SINCE",
-        "SMALL",
-        "STATS",
-        "STILL",
-        "STOCK",
-        "THESE",
-        "TIGHT",
-        "TODAY",
-        "TOTAL",
-        "TRADE",
-        "TREND",
-        "ULTRA",
-        "UNDER",
-        "UPPER",
-        "WATCH",
-        "WEEKS",
-        "WHERE",
-        "WHILE",
-        "WHICH",
-        "WHOSE",
-        "YIELD",
-    }
-)
 
+def _linkify_tickers(html: str, symbols: Collection[str] | None = None) -> str:
+    """Wrap known ticker symbols in TradingView chart links.
 
-def _linkify_tickers(html: str) -> str:
-    """Wrap uppercase ticker tokens in TradingView chart links."""
+    Only exact matches from `symbols` (the actual scan/analysis candidates)
+    are linked — heuristic all-caps matching mislinks indicator acronyms
+    (RSI, ADX), option strikes (430C), and 6+ letter words (EXTREME → EXTRE).
+    With no symbols, the HTML is returned unchanged.
+    """
+    if not symbols:
+        return html
+
+    # Longest-first so overlapping symbols (e.g. "GOOG" vs "GOOGL") match fully.
+    # Boundaries reject adjacent alphanumerics: "430C" must not link a "C" candidate.
+    alternation = "|".join(re.escape(s) for s in sorted(symbols, key=len, reverse=True))
+    ticker_re = re.compile(rf"(?<![A-Za-z0-9<>])({alternation})(?![A-Za-z0-9>])")
 
     def replace(m: re.Match[str]) -> str:
         ticker = m.group(1)
-        if ticker in _SKIP_WORDS:
-            return m.group(0)
         url = f"{_TRADINGVIEW_BASE}{ticker}"
-        return m.group(0).replace(
-            ticker, f'<a href="{url}" rel="noopener noreferrer" target="_blank">{ticker}</a>'
-        )
+        return f'<a href="{url}" rel="noopener noreferrer" target="_blank">{ticker}</a>'
 
     # Only process text nodes — skip tag content and anything inside <a>…</a>.
     parts = re.split(r"(<[^>]+>)", html)
@@ -163,7 +62,7 @@ def _linkify_tickers(html: str) -> str:
         elif in_anchor:
             result.append(part)
         else:
-            result.append(_TICKER_RE.sub(replace, part))
+            result.append(ticker_re.sub(replace, part))
     return "".join(result)
 
 
@@ -175,6 +74,7 @@ def send_briefing_email(
     to_addr: str,
     smtp_host: str = "smtp.gmail.com",
     smtp_port: int = 587,
+    ticker_symbols: Collection[str] | None = None,
 ) -> None:
     """
     Send a briefing email with both plain text and HTML parts.
@@ -187,6 +87,8 @@ def send_briefing_email(
         to_addr: Comma-separated recipient email address(es).
         smtp_host: SMTP server hostname.
         smtp_port: SMTP server port.
+        ticker_symbols: Symbols to wrap in TradingView chart links in the
+            HTML part. None or empty means no linkification.
     """
     recipients = _parse_recipients(to_addr)
 
@@ -203,7 +105,7 @@ def send_briefing_email(
 
     # HTML part (convert markdown to HTML, sanitize, then linkify tickers)
     html_body = nh3.clean(markdown.markdown(body_markdown, extensions=["tables", "fenced_code"]))
-    html_body = _linkify_tickers(html_body)
+    html_body = _linkify_tickers(html_body, ticker_symbols)
     # Wrap in minimal styling for email clients
     html_full = f"""\
 <html>

--- a/src/volume_price_analysis/agent/morning_agent.py
+++ b/src/volume_price_analysis/agent/morning_agent.py
@@ -139,13 +139,16 @@ async def run_morning_briefing(
 
     # Step 4: Deliver
     elapsed_total = time.monotonic() - start_time
+    symbols_scanned = scan_results.get("scan_parameters", {}).get("symbols_scanned")
+    scanned_part = f"{symbols_scanned} symbols scanned | " if symbols_scanned else ""
     stats_line = (
         f"\n\n---\n"
         f"**14-day holding period** - Indicators, expected moves, and strategies "
         f"are calibrated for approx. 14 DTE options. Shorter-duration plays (0-5 DTE) "
         f"may need different setups.\n\n"
         f"*Generated in {elapsed_total:.1f}s | "
-        f"{total_candidates} candidates scanned | "
+        f"{scanned_part}"
+        f"{total_candidates} candidates found | "
         f"{len(deep_analyses)} deep analyses*"
     )
 

--- a/src/volume_price_analysis/agent/morning_agent.py
+++ b/src/volume_price_analysis/agent/morning_agent.py
@@ -181,6 +181,7 @@ async def run_morning_briefing(
             to_addr=config.email_to,
             smtp_host=config.email_smtp_host,
             smtp_port=config.email_smtp_port,
+            ticker_symbols=_candidate_symbols(scan_results, deep_analyses),
         )
 
     logger.info("Morning briefing complete in %.1fs", elapsed_total)
@@ -263,6 +264,18 @@ def _get_top_symbols(scan_results: dict, max_count: int) -> list[str]:
             seen.add(sym)
 
     return symbols[:max_count]
+
+
+def _candidate_symbols(scan_results: dict, deep_analyses: list[dict]) -> set[str]:
+    """Collect every symbol the briefing may mention, for ticker linkification."""
+    symbols = {
+        candidate["symbol"]
+        for key in ("high_conviction_setups", "top_bullish", "top_bearish")
+        for candidate in scan_results.get(key, [])
+        if "symbol" in candidate
+    }
+    symbols.update(a["symbol"] for a in deep_analyses if "symbol" in a)
+    return symbols
 
 
 def _fallback_briefing(scan_results: dict, deep_analyses: list[dict]) -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -47,6 +47,22 @@ from volume_price_analysis.agent.scheduler import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_network_earnings_fetch(mocker):
+    """Keep unit tests off the network.
+
+    run_morning_briefing's earnings guard otherwise makes real yfinance calls
+    (and leaks its sqlite cache connection) for every analysed symbol. Tests
+    that exercise the earnings helpers directly are unaffected: they call the
+    functions through this module's imports, not the patched morning_agent
+    attribute.
+    """
+    mocker.patch(
+        "volume_price_analysis.agent.morning_agent._fetch_earnings_warnings",
+        return_value={},
+    )
+
+
 class TestAgentConfig:
     """Test configuration loading and validation."""
 
@@ -2142,6 +2158,9 @@ class TestMain:
         main()
 
         mock_run.assert_called_once()
+        # Close the real coroutine main() handed to the mocked asyncio.run,
+        # else it warns "coroutine was never awaited" at GC time.
+        mock_run.call_args[0][0].close()
 
     def test_main_config_validation_failure_exits(self, mocker):
         """Config validation errors cause sys.exit(1)."""
@@ -2181,6 +2200,9 @@ class TestMain:
         main()
 
         mock_run.assert_called_once()
+        # Close the real coroutine main() handed to the mocked asyncio.run,
+        # else it warns "coroutine was never awaited" at GC time.
+        mock_run.call_args[0][0].close()
 
     def test_main_dry_run_with_ai_needs_api_key(self, mocker):
         """--dry-run without --no-ai still validates AI config."""
@@ -2220,6 +2242,9 @@ class TestMain:
         main()
 
         mock_run.assert_called_once()
+        # Close the real coroutine main() handed to the mocked asyncio.run,
+        # else it warns "coroutine was never awaited" at GC time.
+        mock_run.call_args[0][0].close()
 
     def test_main_dry_run_with_valid_ai_config_succeeds(self, mocker):
         """--dry-run with valid AI config passes validation."""
@@ -2241,6 +2266,9 @@ class TestMain:
         main()
 
         mock_run.assert_called_once()
+        # Close the real coroutine main() handed to the mocked asyncio.run,
+        # else it warns "coroutine was never awaited" at GC time.
+        mock_run.call_args[0][0].close()
 
     def test_main_critical_failure_sends_error_email(self, mocker):
         """Critical exception triggers send_error_email and sys.exit(1)."""
@@ -2255,7 +2283,7 @@ class TestMain:
                 email_to="c@d.com",
             ),
         )
-        mocker.patch(
+        mock_run = mocker.patch(
             "volume_price_analysis.agent.morning_agent.asyncio.run",
             side_effect=RuntimeError("Critical failure"),
         )
@@ -2269,6 +2297,8 @@ class TestMain:
 
         mock_send_error.assert_called_once()
         assert "Critical failure" in mock_send_error.call_args.kwargs["error_message"]
+        # Close the real coroutine main() handed to the mocked asyncio.run.
+        mock_run.call_args[0][0].close()
 
     def test_main_critical_failure_dry_run_no_error_email(self, mocker):
         """dry-run critical failure does NOT send error email."""
@@ -2283,7 +2313,7 @@ class TestMain:
                 email_to="c@d.com",
             ),
         )
-        mocker.patch(
+        mock_run = mocker.patch(
             "volume_price_analysis.agent.morning_agent.asyncio.run",
             side_effect=RuntimeError("Critical failure"),
         )
@@ -2296,6 +2326,8 @@ class TestMain:
         assert exc_info.value.code == 1
 
         mock_send_error.assert_not_called()
+        # Close the real coroutine main() handed to the mocked asyncio.run.
+        mock_run.call_args[0][0].close()
 
     def test_main_critical_failure_missing_email_password_skips_error_email(self, mocker):
         """Missing email_password means error email is not sent on failure."""
@@ -2329,7 +2361,7 @@ class TestMain:
                 email_to="c@d.com",
             ),
         )
-        mocker.patch(
+        mock_run = mocker.patch(
             "volume_price_analysis.agent.morning_agent.asyncio.run",
             return_value=False,
         )
@@ -2337,6 +2369,8 @@ class TestMain:
         with pytest.raises(SystemExit) as exc_info:
             main()
         assert exc_info.value.code == 2
+        # Close the real coroutine main() handed to the mocked asyncio.run.
+        mock_run.call_args[0][0].close()
 
 
 class TestSubjectHeaderInjection:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1438,12 +1438,17 @@ class TestRunLoop:
 
         stop_event = asyncio.Event()
 
-        # Schedule stop_event.set() to fire during the await inside the loop body
-        async def set_stop_soon():
-            await asyncio.sleep(0)
+        # The mocked past date makes delay=0, so the loop body runs immediately.
+        # Stub the briefing (a real one would hit the network) and use it to
+        # stop the loop after one iteration.
+        async def fake_briefing(cfg):
             stop_event.set()
+            return True
 
-        asyncio.create_task(set_stop_soon())
+        mocker.patch(
+            "volume_price_analysis.agent.scheduler.run_morning_briefing",
+            side_effect=fake_briefing,
+        )
 
         await _run_loop(time(8, 30), ET, stop_event, skip_holidays=True)
 
@@ -1477,11 +1482,17 @@ class TestRunLoop:
 
         stop_event = asyncio.Event()
 
-        async def set_stop_soon():
-            await asyncio.sleep(0)
+        # The mocked past date makes delay=0, so the loop body runs immediately.
+        # Stub the briefing (a real one would hit the network) and use it to
+        # stop the loop after one iteration.
+        async def fake_briefing(cfg):
             stop_event.set()
+            return True
 
-        asyncio.create_task(set_stop_soon())
+        mocker.patch(
+            "volume_price_analysis.agent.scheduler.run_morning_briefing",
+            side_effect=fake_briefing,
+        )
 
         await _run_loop(time(8, 30), ET, stop_event, skip_holidays=False)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -27,6 +27,7 @@ from volume_price_analysis.agent.email_sender import (
     send_raw_data_email,
 )
 from volume_price_analysis.agent.morning_agent import (
+    _candidate_symbols,
     _check_earnings,
     _fallback_briefing,
     _fetch_earnings_warnings,
@@ -208,6 +209,27 @@ class TestGetTopSymbols:
         }
         symbols = _get_top_symbols(scan_results, 5)
         assert symbols == []
+
+
+class TestCandidateSymbols:
+    """Test symbol collection for ticker linkification."""
+
+    def test_collects_from_all_lists(self):
+        scan_results = {
+            "high_conviction_setups": [{"symbol": "NVDA"}],
+            "top_bullish": [{"symbol": "AAPL"}, {"symbol": "NVDA"}],
+            "top_bearish": [{"symbol": "TSLA"}],
+        }
+        deep_analyses = [{"symbol": "MSFT"}, {"score": 1.0}]
+        assert _candidate_symbols(scan_results, deep_analyses) == {
+            "NVDA",
+            "AAPL",
+            "TSLA",
+            "MSFT",
+        }
+
+    def test_handles_empty_results(self):
+        assert _candidate_symbols({}, []) == set()
 
 
 class TestFallbackBriefing:
@@ -2572,32 +2594,62 @@ class TestLinkifyTickers:
 
     def test_wraps_ticker_in_tradingview_link(self):
         html = "<p><strong>AAPL</strong> looks bullish.</p>"
-        result = _linkify_tickers(html)
+        result = _linkify_tickers(html, {"AAPL"})
         assert 'href="https://www.tradingview.com/chart/?symbol=AAPL"' in result
         assert ">AAPL<" in result
 
-    def test_skips_common_words(self):
-        html = "<p>THE stock AND the market.</p>"
-        result = _linkify_tickers(html)
-        assert "THE" in result
-        assert 'symbol=THE"' not in result
-        assert 'symbol=AND"' not in result
+    def test_no_symbols_returns_unchanged(self):
+        html = "<p>AAPL and NVDA look bullish.</p>"
+        assert _linkify_tickers(html) == html
+        assert _linkify_tickers(html, set()) == html
+
+    def test_only_links_whitelisted_symbols(self):
+        html = "<p>AAPL is up but NVDA is down.</p>"
+        result = _linkify_tickers(html, {"AAPL"})
+        assert 'symbol=AAPL"' in result
+        assert 'symbol=NVDA"' not in result
+
+    def test_skips_indicator_acronyms(self):
+        html = "<p>RSI is 26.7 and ADX is 47.0 with HV at 21.5%.</p>"
+        result = _linkify_tickers(html, {"BSX"})
+        assert "<a " not in result
+
+    def test_does_not_truncate_long_caps_words(self):
+        html = "<p>EXTREME OVERSOLD CONDITION.</p>"
+        result = _linkify_tickers(html, {"EXTRE", "OVERS", "CONDI"})
+        assert "<a " not in result
+
+    def test_does_not_link_option_strikes(self):
+        html = "<p>Buy the 430C and sell the 475C.</p>"
+        result = _linkify_tickers(html, {"C"})
+        assert "<a " not in result
+
+    def test_links_common_word_ticker_when_candidate(self):
+        html = "<p><strong>HAS</strong> shows a bullish divergence.</p>"
+        result = _linkify_tickers(html, {"HAS"})
+        assert 'symbol=HAS"' in result
+
+    def test_longest_symbol_wins_overlap(self):
+        html = "<p>GOOGL broke out.</p>"
+        result = _linkify_tickers(html, {"GOOG", "GOOGL"})
+        assert 'symbol=GOOGL"' in result
+        assert 'symbol=GOOG"' not in result
 
     def test_does_not_double_link(self):
         html = '<p><a href="https://example.com">TSLA</a> is volatile.</p>'
-        result = _linkify_tickers(html)
+        result = _linkify_tickers(html, {"TSLA"})
         assert result.count("<a ") == 1
 
     def test_skips_html_tag_content(self):
         html = '<div CLASS="foo">NVDA is up</div>'
-        result = _linkify_tickers(html)
+        result = _linkify_tickers(html, {"CLASS", "NVDA"})
         assert 'symbol=CLASS"' not in result
         assert 'symbol=NVDA"' in result
 
-    def test_5_char_ticker(self):
-        html = "<p>GOOGL broke out.</p>"
-        result = _linkify_tickers(html)
-        assert 'symbol=GOOGL"' in result
+    def test_hyphenated_symbol(self):
+        html = "<p>BRK-B is consolidating.</p>"
+        result = _linkify_tickers(html, {"BRK-B"})
+        assert 'symbol=BRK-B"' in result
 
     def test_empty_string(self):
-        assert _linkify_tickers("") == ""
+        assert _linkify_tickers("", {"AAPL"}) == ""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -13,6 +13,7 @@ from volume_price_analysis.agent.ai_client import (
     _TRUNCATION_WARNING,
     SYSTEM_PROMPT,
     _build_user_message,
+    _drop_superseded_scan_fields,
     _project_deep_analysis,
     _project_scan_results,
     find_ungrounded_tickers,
@@ -412,6 +413,55 @@ class TestProjectScanResults:
         assert _project_scan_results({"summary": {}}) == {"summary": {}}
 
 
+class TestDropSupersededScanFields:
+    """Scan-level targets must be dropped for symbols that have a deep analysis."""
+
+    def _scan(self):
+        return {
+            "summary": {"total_candidates": 2},
+            "top_bullish": [
+                {
+                    "symbol": "BSX",
+                    "composite_score": -4.0,
+                    "expected_move_pct": 6.4,
+                    "key_levels": {"upper_target": 45.8, "lower_target": 40.32},
+                },
+                {
+                    "symbol": "AAPL",
+                    "composite_score": 3.0,
+                    "expected_move_pct": 4.1,
+                    "key_levels": {"upper_target": 160.0, "lower_target": 148.0},
+                },
+            ],
+        }
+
+    def test_strips_targets_for_deep_analyzed_symbols(self):
+        result = _drop_superseded_scan_fields(self._scan(), [{"symbol": "BSX"}])
+        bsx, aapl = result["top_bullish"]
+        # BSX has a deep analysis: its scan targets would conflict, so drop them.
+        assert "key_levels" not in bsx
+        assert "expected_move_pct" not in bsx
+        assert bsx["composite_score"] == -4.0
+        # AAPL has no deep analysis: its scan targets are the only ones, keep them.
+        assert aapl["key_levels"]["lower_target"] == 148.0
+        assert aapl["expected_move_pct"] == 4.1
+
+    def test_does_not_mutate_input(self):
+        scan = self._scan()
+        _drop_superseded_scan_fields(scan, [{"symbol": "BSX"}])
+        assert "key_levels" in scan["top_bullish"][0]
+
+    def test_no_deep_analyses_returns_unchanged(self):
+        scan = self._scan()
+        assert _drop_superseded_scan_fields(scan, []) is scan
+
+    def test_handles_malformed_entries(self):
+        scan = {"top_bullish": "not-a-list", "top_bearish": [None, {"symbol": "BSX"}]}
+        result = _drop_superseded_scan_fields(scan, [{"symbol": "BSX"}, "junk", {}])
+        assert result["top_bullish"] == "not-a-list"
+        assert result["top_bearish"][0] is None
+
+
 class TestProjectDeepAnalysis:
     """Test the curated deep-analysis projection (O3)."""
 
@@ -501,6 +551,30 @@ class TestBuildUserMessageProjection:
         # Internal scoring detail is dropped from the model-facing prompt.
         assert "score_breakdown" not in curated
         assert "plus_di" not in curated
+
+    def test_deep_analyzed_symbol_gets_single_target_source(self):
+        # A symbol with a deep analysis must not also carry scan-level targets:
+        # the two are computed from different data windows and the model would
+        # cite both (e.g. "$40.32 scan target" vs "$39.75 lower target").
+        scan = {
+            "summary": {"total_candidates": 1},
+            "top_bearish": [
+                {
+                    "symbol": "BSX",
+                    "expected_move_pct": 6.4,
+                    "key_levels": {"upper_target": 45.8, "lower_target": 40.32},
+                }
+            ],
+        }
+        deep = {
+            "symbol": "BSX",
+            "volatility_analysis": {
+                "expected_move": {"upper_target": 46.37, "lower_target": 39.75},
+            },
+        }
+        curated = _build_user_message(scan, [deep])
+        assert "40.32" not in curated
+        assert "39.75" in curated
 
 
 class TestGenerateBriefingAnthropic:
@@ -1954,6 +2028,86 @@ class TestDryRunNoAi:
         assert "total_candidates" in captured.out
 
 
+class TestStatsLineFooter:
+    """The footer must distinguish symbols scanned from candidates found."""
+
+    @pytest.mark.asyncio
+    async def test_footer_reports_scanned_and_found_separately(self, mocker, capsys):
+        scan_data = {
+            "scan_parameters": {"symbols_scanned": 540},
+            "summary": {
+                "total_candidates": 96,
+                "bullish_setups": 47,
+                "bearish_setups": 49,
+                "high_conviction": 4,
+                "errors": 0,
+            },
+            "high_conviction_setups": [],
+            "top_bullish": [],
+            "top_bearish": [],
+        }
+        mocker.patch(
+            "volume_price_analysis.agent.morning_agent.run_scan",
+            return_value=scan_data,
+        )
+        mocker.patch(
+            "volume_price_analysis.agent.morning_agent.generate_briefing",
+            return_value="Briefing body",
+        )
+
+        config = AgentConfig(
+            ai_provider="gemini",
+            ai_provider_api_key="test-key",
+            email_from="a@b.com",
+            email_password="pass",
+            email_to="c@d.com",
+        )
+
+        await run_morning_briefing(config, dry_run=True)
+
+        captured = capsys.readouterr()
+        assert "540 symbols scanned" in captured.out
+        assert "96 candidates found" in captured.out
+        assert "candidates scanned" not in captured.out
+
+    @pytest.mark.asyncio
+    async def test_footer_omits_scanned_count_when_absent(self, mocker, capsys):
+        scan_data = {
+            "summary": {
+                "total_candidates": 3,
+                "bullish_setups": 2,
+                "bearish_setups": 1,
+                "high_conviction": 0,
+                "errors": 0,
+            },
+            "high_conviction_setups": [],
+            "top_bullish": [],
+            "top_bearish": [],
+        }
+        mocker.patch(
+            "volume_price_analysis.agent.morning_agent.run_scan",
+            return_value=scan_data,
+        )
+        mocker.patch(
+            "volume_price_analysis.agent.morning_agent.generate_briefing",
+            return_value="Briefing body",
+        )
+
+        config = AgentConfig(
+            ai_provider="gemini",
+            ai_provider_api_key="test-key",
+            email_from="a@b.com",
+            email_password="pass",
+            email_to="c@d.com",
+        )
+
+        await run_morning_briefing(config, dry_run=True)
+
+        captured = capsys.readouterr()
+        assert "symbols scanned" not in captured.out
+        assert "3 candidates found" in captured.out
+
+
 class TestMain:
     """Test the main() entry point (lines 212-252, 256)."""
 
@@ -2354,6 +2508,24 @@ class TestSystemPromptGrounding:
     def test_prompt_mentions_tickers_must_come_from_data(self):
         lowered = SYSTEM_PROMPT.lower()
         assert "ticker" in lowered
+
+
+class TestSystemPromptConsistency:
+    """The prompt must forbid conflicting values and overstated target labels."""
+
+    def test_prompt_requires_one_value_per_metric(self):
+        lowered = SYSTEM_PROMPT.lower()
+        assert "one value per metric" in lowered
+        assert "deep-analysis values" in lowered
+
+    def test_prompt_labels_targets_as_one_sigma_expected_move(self):
+        lowered = SYSTEM_PROMPT.lower()
+        assert "standard deviation" in lowered
+        assert "not as predictions" in lowered
+
+    def test_prompt_clarifies_hv_percentile_is_relative(self):
+        lowered = SYSTEM_PROMPT.lower()
+        assert "own recent history" in lowered
 
 
 class TestFindUngroundedTickers:

--- a/uv.lock
+++ b/uv.lock
@@ -1304,8 +1304,8 @@ name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
@@ -1314,7 +1314,7 @@ wheels = [
 
 [[package]]
 name = "volume-price-analysis-mcp"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -360,6 +360,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1003,6 +1012,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1336,6 +1358,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1360,6 +1383,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-mock", specifier = "==3.15.1" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "ruff", specifier = "==0.15.20" },
 ]
 


### PR DESCRIPTION
## Problem

The briefing email's ticker linkifier pattern-matched any standalone 1–5 letter all-caps token and relied on a blocklist of English words. Today's briefing showed every failure mode at once:

- **Indicator acronyms linked as tickers**: RSI, ADX, HV, MFI, POC, DTE all got TradingView chart links (HV, RSI, DTE resolve to real but unrelated instruments).
- **Long all-caps words truncated**: the regex's lookahead rejected a following lowercase letter but not an uppercase one, so "EXTREME OVERSOLD CONDITION" rendered as three links — **EXTRE**ME, **OVERS**OLD, **CONDI**TION.
- **Option strikes linked**: digits were allowed before a match, so "430C" / "475C" linked the C to Citigroup's chart.
- **False negatives**: actual candidate **HAS** (Hasbro) was suppressed by the blocklist — the only symbol in the report without a chart link.

The same briefing also exposed three content-accuracy issues:

- **Conflicting targets**: BSX cited both a "$40.32 scan target" and a "$39.75 14-day lower target" — the scan and deep analysis compute 1σ expected-move targets from different data windows, and the model received both.
- **Misleading footer**: "96 candidates scanned" when 540 symbols were scanned and 96 *met criteria*.
- **Overstated labels**: 1σ expected-move targets presented as "14-Day Upper Target" price objectives, and low HV percentile framed as if it implied a small absolute move.

## Fix

**Linkifier (commit 1)** — invert the approach: `_linkify_tickers()` now takes the actual candidate symbols from the scan results and deep analyses, and links only exact matches with strict alphanumeric boundaries (longest-first alternation so overlapping symbols like GOOG/GOOGL match fully, `re.escape` for hyphenated symbols like BRK-B).

- `send_briefing_email()` gains an optional `ticker_symbols` parameter; no symbols → no linkification.
- `morning_agent` passes every symbol from `high_conviction_setups`, `top_bullish`, `top_bearish`, and the deep analyses via new `_candidate_symbols()` helper.
- Raw-data (`--no-ai`) emails no longer linkify — previously links were injected into JSON code blocks.
- `_SKIP_WORDS` blocklist deleted (~100 lines).

**Briefing content (commit 2)**:

- New `_drop_superseded_scan_fields()` strips scan-level `key_levels` / `expected_move_pct` from candidates that also have a deep analysis, so the model never sees two competing targets for one symbol. Candidates without a deep analysis keep their scan targets.
- Footer now reads "540 symbols scanned | 96 candidates found" (scanned count omitted gracefully when absent).
- `SYSTEM_PROMPT`: cite one value per metric per symbol (deep analysis supersedes scan); label `upper_target`/`lower_target` as a ±1σ expected move, not predictions; clarify HV percentile ranks the symbol against its own history.

## Testing

- Rewrote `TestLinkifyTickers` with regression cases for each linkifier failure mode, plus overlap, hyphenated symbols, and anchor/tag skipping.
- Added `TestCandidateSymbols`, `TestDropSupersededScanFields`, `TestSystemPromptConsistency`, `TestStatsLineFooter`, and a `_build_user_message` integration test asserting the conflicting BSX target disappears from the model prompt.
- Full suite: 637 passed, coverage 97.5%; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Test speed (commit 3)**:

- The two `TestRunLoop` holiday tests mocked `_next_run` to a past date, making the loop fall through to an **unmocked** `run_morning_briefing` — a real ~10s network market scan per test. Now stubbed; both tests run in 0.3s.
- Added `pytest-xdist` with `-n auto` in `addopts`: full suite drops from ~36s to ~8s wall clock. Coverage aggregates across workers (96.6%). Use `-n 0` for serial debugging.
