### PR TITLE
feat(server): expose causal RSI-divergence detector as dedicated MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ VWAP, Volume Profile, Money Flow Index, and more.
 9. **comprehensive_analysis** - Complete analysis with all indicators
 10. **options_analysis** - Specialized analysis for short-term options trading
 11. **scan_candidates** - Scan ~200 symbols for top options trading candidates
+12. **calculate_rsi_divergence** - Causal pivot-based RSI divergence detector (standalone)
 
 ### Key Indicators Explained
 

--- a/src/volume_price_analysis/indicators.py
+++ b/src/volume_price_analysis/indicators.py
@@ -1159,6 +1159,28 @@ def calculate_rsi_with_divergence(
     }
 
 
+def calculate_rsi_divergence(
+    data: pd.DataFrame, period: int = 14, divergence_lookback: int = 10
+) -> dict[str, Any]:
+    """JSON-serializable RSI-divergence result for the standalone MCP tool.
+
+    Wraps :func:`calculate_rsi_with_divergence`, dropping ``rsi_series``
+    so the output can be safely serialized to JSON.
+    """
+    inner = calculate_rsi_with_divergence(data, period, divergence_lookback)
+    return {
+        "rsi": inner["rsi"],
+        "condition": inner["condition"],
+        "period": inner["period"],
+        "bullish_divergence": inner["bullish_divergence"],
+        "bearish_divergence": inner["bearish_divergence"],
+        "divergence_type": inner["divergence_type"],
+        "signal": inner["signal"],
+        "interpretation": inner["interpretation"],
+        "current_rsi": inner["current_rsi"],
+    }
+
+
 # ============================================================================
 # OPTIONS-SPECIFIC CALCULATIONS
 # ============================================================================

--- a/src/volume_price_analysis/server.py
+++ b/src/volume_price_analysis/server.py
@@ -31,6 +31,7 @@ from .indicators import (
     calculate_obv,
     calculate_price_roc,
     calculate_relative_volume,
+    calculate_rsi_divergence,
     calculate_volume_profile,
     calculate_vpt,
     calculate_vwap,
@@ -522,6 +523,56 @@ async def handle_list_tools() -> list[Tool]:
                 "required": [],
             },
         ),
+        Tool(
+            name="calculate_rsi_divergence",
+            description=(
+                "Detect causal RSI divergence at the latest bar using pivot-based analysis. "
+                "Bullish divergence: price makes a lower low while RSI makes a higher low "
+                "(potential reversal up). Bearish divergence: price makes a higher high while "
+                "RSI makes a lower high (potential reversal down). Uses confirmed swing pivots "
+                "only — no lookahead. Default period '3mo' to ensure enough pivots."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "description": "Stock ticker symbol",
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date in YYYY-MM-DD format (optional)",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date in YYYY-MM-DD format (optional)",
+                    },
+                    "period": {
+                        "type": "string",
+                        "description": (
+                            "Period if dates not specified (default: '3mo'). "
+                            "At least 3mo recommended — 1mo rarely holds two confirmed pivots."
+                        ),
+                        "default": "3mo",
+                    },
+                    "rsi_period": {
+                        "type": "integer",
+                        "description": "RSI calculation period (default: 14)",
+                        "default": 14,
+                        "minimum": 1,
+                        "maximum": 200,
+                    },
+                    "divergence_lookback": {
+                        "type": "integer",
+                        "description": "Minimum bars for divergence history gate (default: 10)",
+                        "default": 10,
+                        "minimum": 5,
+                        "maximum": 200,
+                    },
+                },
+                "required": ["symbol"],
+            },
+        ),
     ]
 
 
@@ -557,6 +608,7 @@ async def handle_call_tool(name: str, arguments: dict) -> CallToolResult:
             "analyze_volume_trends",
             "comprehensive_analysis",
             "options_analysis",
+            "calculate_rsi_divergence",
         }
         if name not in single_symbol_tools:
             raise ValueError(f"Unknown tool: {name}")
@@ -569,7 +621,8 @@ async def handle_call_tool(name: str, arguments: dict) -> CallToolResult:
         end_date = arguments.get("end_date")
 
         # Set default period based on tool type
-        default_period = "3mo" if name == "options_analysis" else "1mo"
+        long_period_tools = {"options_analysis", "calculate_rsi_divergence"}
+        default_period = "3mo" if name in long_period_tools else "1mo"
         period = arguments.get("period", default_period)
 
         # Validate tool-specific integer parameters before fetching data (fail fast)
@@ -589,6 +642,9 @@ async def handle_call_tool(name: str, arguments: dict) -> CallToolResult:
                 1,
                 365,
             )
+        elif name == "calculate_rsi_divergence":
+            _validate_range(arguments.get("rsi_period", 14), "rsi_period", 1, 200)
+            _validate_range(arguments.get("divergence_lookback", 10), "divergence_lookback", 5, 200)
 
         # Fetch stock data
         data = fetch_stock_data(symbol, start_date, end_date, period)
@@ -957,6 +1013,13 @@ async def handle_call_tool(name: str, arguments: dict) -> CallToolResult:
                 days_to_expiration=days_to_expiration,
             )
 
+            return CallToolResult(content=[TextContent(type="text", text=_json_response(result))])
+
+        elif name == "calculate_rsi_divergence":
+            rsi_period = arguments.get("rsi_period", 14)
+            divergence_lookback = arguments.get("divergence_lookback", 10)
+            divergence_result = calculate_rsi_divergence(data, rsi_period, divergence_lookback)
+            result = {"symbol": symbol, **divergence_result}
             return CallToolResult(content=[TextContent(type="text", text=_json_response(result))])
 
         raise AssertionError(f"Unhandled tool: {name}")  # pragma: no cover

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,9 +40,10 @@ class TestListTools:
             "comprehensive_analysis",
             "options_analysis",
             "scan_candidates",
+            "calculate_rsi_divergence",
         ]
 
-        assert len(tools) == 11
+        assert len(tools) == 12
         for expected_tool in expected_tools:
             assert expected_tool in tool_names
 
@@ -1556,3 +1557,92 @@ class TestServerVersion:
         from volume_price_analysis.server import _SERVER_VERSION
 
         assert isinstance(_SERVER_VERSION, str) and _SERVER_VERSION
+
+
+class TestCallToolRSIDivergence:
+    """Tests for calculate_rsi_divergence tool."""
+
+    def _make_data(self, n: int = 60) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Date": pd.date_range(start="2024-01-01", periods=n, freq="D"),
+                "Open": [100.0 + i * 0.5 for i in range(n)],
+                "High": [102.0 + i * 0.5 for i in range(n)],
+                "Low": [98.0 + i * 0.5 for i in range(n)],
+                "Close": [100.5 + i * 0.5 for i in range(n)],
+                "Volume": [1_000_000] * n,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_listed(self):
+        """calculate_rsi_divergence appears in handle_list_tools."""
+        tools = await handle_list_tools()
+        names = [t.name for t in tools]
+        assert "calculate_rsi_divergence" in names
+
+    @pytest.mark.asyncio
+    @patch("volume_price_analysis.server.fetch_stock_data")
+    async def test_called_returns_expected_keys(self, mock_fetch):
+        """Tool returns symbol + all divergence result keys."""
+        mock_fetch.return_value = self._make_data()
+
+        result = await handle_call_tool(
+            name="calculate_rsi_divergence",
+            arguments={"symbol": "AAPL", "period": "3mo"},
+        )
+
+        assert not result.isError
+        data = json.loads(result.content[0].text)
+        assert data["symbol"] == "AAPL"
+        for key in (
+            "rsi",
+            "condition",
+            "period",
+            "bullish_divergence",
+            "bearish_divergence",
+            "divergence_type",
+            "signal",
+            "interpretation",
+            "current_rsi",
+        ):
+            assert key in data, f"Missing key: {key}"
+
+    @pytest.mark.asyncio
+    @patch("volume_price_analysis.server.fetch_stock_data")
+    async def test_custom_params_passed_through(self, mock_fetch):
+        """rsi_period and divergence_lookback are forwarded correctly."""
+        mock_fetch.return_value = self._make_data(80)
+
+        result = await handle_call_tool(
+            name="calculate_rsi_divergence",
+            arguments={"symbol": "MSFT", "rsi_period": 9, "divergence_lookback": 15},
+        )
+
+        assert not result.isError
+        data = json.loads(result.content[0].text)
+        assert data["period"] == 9
+
+    @pytest.mark.asyncio
+    async def test_error_invalid_rsi_period(self):
+        """Out-of-range rsi_period returns an error response."""
+        result = await handle_call_tool(
+            name="calculate_rsi_divergence",
+            arguments={"symbol": "TSLA", "rsi_period": 0},
+        )
+
+        assert result.isError
+        data = json.loads(result.content[0].text)
+        assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_error_missing_symbol(self):
+        """Missing symbol returns an error response."""
+        result = await handle_call_tool(
+            name="calculate_rsi_divergence",
+            arguments={"symbol": ""},
+        )
+
+        assert result.isError
+        data = json.loads(result.content[0].text)
+        assert "error" in data


### PR DESCRIPTION
## Summary

- Adds `calculate_rsi_divergence` as a standalone MCP tool (#12), previously only reachable inside `options_analysis`/`scan_candidates`
- New public JSON-safe wrapper in `indicators.py` wraps `calculate_rsi_with_divergence`, dropping the non-serializable `rsi_series`; the underlying causal `detect_rsi_divergence` pivot detector is left untouched
- Server wiring: Tool definition, `single_symbol_tools` set, param validation (`rsi_period` 1–200, `divergence_lookback` 5–200), handler; defaults `period` to `'3mo'` (1mo rarely holds two confirmed pivots)

## Test plan

- [x] `TestListTools` — tool count bumped 11→12, `calculate_rsi_divergence` in expected list
- [x] `TestCallToolRSIDivergence` — listed / called (all 9 output keys) / custom-params forwarded / error on bad rsi_period / error on missing symbol
- [x] All 77 tests pass (`uv run pytest tests/test_server.py -n 0`)
- [x] `ruff check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)